### PR TITLE
Add .gitignore entries for sensitive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,13 +47,9 @@ htmlcov/
 .dmypy.json
 dmypy.json
 
-# Secrets / credentials
+# Environment files
 .env
 .env.*
-*.pem
-*.key
-*.p12
-credentials.json
 
 # Garmin tokens
 .garminconnect/

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,14 @@ htmlcov/
 .dmypy.json
 dmypy.json
 
+# Secrets / credentials
+.env
+.env.*
+*.pem
+*.key
+*.p12
+credentials.json
+
 # Garmin tokens
 .garminconnect/
 


### PR DESCRIPTION
The .gitignore is missing entries for `.env` files and private keys (`*.pem`, `*.key`). Added those along with `*.p12` and `credentials.json` to help prevent accidental commits of credentials.