### PR TITLE
fix: detect activity file format from magic bytes instead of assuming .FIT files

### DIFF
--- a/garmin_health_data/cli.py
+++ b/garmin_health_data/cli.py
@@ -317,6 +317,12 @@ def extract(
                                 fg="yellow",
                             )
 
+                    # Skip this timestamp group if no files matched a known type.
+                    # This happens when all downloaded files are in formats that
+                    # the processor does not yet support (e.g. TCX, GPX).
+                    if not files_by_type:
+                        continue
+
                     # Create FileSet for this timestamp
                     file_set = FileSet(file_paths=timestamp_files, files=files_by_type)
 

--- a/garmin_health_data/cli.py
+++ b/garmin_health_data/cli.py
@@ -324,7 +324,10 @@ def extract(
                         continue
 
                     # Create FileSet for this timestamp
-                    file_set = FileSet(file_paths=timestamp_files, files=files_by_type)
+                    # Derive file_paths from matched files only to ensure the processor
+                    # only receives files it can handle (those matching GARMIN_FILE_TYPES).
+                    matched_paths = [p for paths in files_by_type.values() for p in paths]
+                    file_set = FileSet(file_paths=matched_paths, files=files_by_type)
 
                     # Process this FileSet
                     processor = GarminProcessor(file_set, session)

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -28,7 +28,7 @@ from garmin_health_data.constants import (
 
 # File extensions that the downstream processor knows how to route.
 # Used as a fallback when magic-byte detection is inconclusive.
-_KNOWN_ACTIVITY_EXTENSIONS: frozenset = frozenset({"fit", "tcx", "gpx", "kml"})
+_KNOWN_ACTIVITY_EXTENSIONS: frozenset[str] = frozenset({"fit", "tcx", "gpx", "kml"})
 
 
 def _detect_format_from_magic(content: bytes) -> Optional[str]:
@@ -399,7 +399,7 @@ class GarminExtractor:
 
     def _extract_activity_content(
         self, activity_id: int, raw_data: bytes
-    ) -> Optional[tuple]:
+    ) -> Optional[tuple[str, bytes]]:
         """
         Extract and identify the content of a downloaded activity file.
 

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -18,6 +18,7 @@ from typing import List, Optional, Union, Callable, Dict
 import click
 import pendulum
 from garmin_health_data.garmin_client import ActivityDownloadFormat, GarminClient
+from garmin_health_data.garmin_client.exceptions import GarminConnectionError
 
 from garmin_health_data.constants import (
     APIMethodTimeParam,
@@ -529,10 +530,21 @@ class GarminExtractor:
             timestamp = pendulum.instance(midday_dt, tz="UTC").to_iso8601_string()
 
             # Download activity file (ORIGINAL format = ZIP archive).
-            raw_data = self.garmin_client.download_activity(
-                activity_id,
-                dl_fmt=ActivityDownloadFormat.ORIGINAL,
-            )
+            # A 404 means the activity exists in the list but has no
+            # downloadable file (manually entered activity, deleted upload,
+            # or a very old activity whose file is no longer retained by
+            # Garmin). Skip and continue rather than aborting the run.
+            try:
+                raw_data = self.garmin_client.download_activity(
+                    activity_id,
+                    dl_fmt=ActivityDownloadFormat.ORIGINAL,
+                )
+            except GarminConnectionError as e:
+                click.secho(
+                    f"⚠️  Skipping activity {activity_id}: {e}.",
+                    fg="yellow",
+                )
+                continue
 
             # Detect actual file format and extract content.
             result = self._extract_activity_content(activity_id, raw_data)

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -1,7 +1,7 @@
 """
 Garmin Connect data extraction module for standalone use.
 
-Extracts FIT activity files and JSON Garmin data from Garmin Connect API and saves them
+Extracts activity files and JSON Garmin data from Garmin Connect API and saves them
 to the ingest directory. Designed for standalone applications without Apache Airflow
 dependencies.
 """
@@ -24,6 +24,45 @@ from garmin_health_data.constants import (
     GarminDataType,
     GARMIN_DATA_REGISTRY,
 )
+
+# File extensions that the downstream processor knows how to route.
+# Used as a fallback when magic-byte detection is inconclusive.
+_KNOWN_ACTIVITY_EXTENSIONS: frozenset = frozenset({"fit", "tcx", "gpx", "kml"})
+
+
+def _detect_format_from_magic(content: bytes) -> Optional[str]:
+    """
+    Detect activity file format from magic bytes.
+
+    Uses format-specific byte signatures rather than filename extensions,
+    which are not guaranteed to be accurate for Garmin's download service.
+    Returns ``None`` for unrecognised content so the caller can apply a
+    fallback strategy.
+
+    Detection rules:
+    - FIT: bytes 8–11 equal ``b'.FIT'`` (ANT+ FIT protocol header).
+    - TCX: XML content containing ``<TrainingCenterDatabase``.
+    - GPX: XML content containing ``<gpx``.
+    - KML: XML content containing ``<kml``.
+
+    :param content: Raw bytes of the activity file.
+    :return: Lowercase file extension (``'fit'``, ``'tcx'``, ``'gpx'``,
+        ``'kml'``), or ``None`` if the format cannot be identified.
+    """
+    # FIT: ANT+ FIT protocol magic bytes at offset 8–11.
+    if len(content) >= 12 and content[8:12] == b".FIT":
+        return "fit"
+
+    # XML-based formats: inspect a small header prefix for the root element.
+    text_head = content[:512].decode("utf-8", errors="ignore")
+    if "<TrainingCenterDatabase" in text_head:
+        return "tcx"
+    if "<gpx" in text_head:
+        return "gpx"
+    if "<kml" in text_head:
+        return "kml"
+
+    return None
 
 
 class GarminExtractor:
@@ -357,23 +396,105 @@ class GarminExtractor:
         click.echo(f"Saved {data_type.emoji} {data_type.name}: {filename}.")
         return [filepath]
 
+    def _extract_activity_content(
+        self, activity_id: int, raw_data: bytes
+    ) -> Optional[tuple]:
+        """
+        Extract and identify the content of a downloaded activity file.
+
+        Garmin's ORIGINAL download format returns a ZIP archive whose inner
+        file may be FIT, TCX, GPX, or another format depending on how the
+        activity was originally recorded or uploaded. This method extracts
+        the content and identifies the format using magic bytes, so the saved
+        filename carries the correct extension regardless of what Garmin puts
+        inside the ZIP.
+
+        Fallback chain when magic bytes are inconclusive:
+        1. Inner filename extension (if it is a known activity extension).
+        2. ``'.bin'`` — file is preserved on disk but will not be processed.
+
+        :param activity_id: Garmin activity ID (used in log messages).
+        :param raw_data: Raw bytes returned by the download API.
+        :return: Tuple of ``(file_extension, content_bytes)``, or ``None``
+            if the archive is empty.
+        """
+        inner_name = ""
+
+        try:
+            with zipfile.ZipFile(io.BytesIO(raw_data), "r") as zip_ref:
+                zip_files = zip_ref.namelist()
+                if not zip_files:
+                    click.secho(
+                        f"⚠️  Empty ZIP archive for activity {activity_id}.",
+                        fg="yellow",
+                    )
+                    return None
+
+                if len(zip_files) > 1:
+                    click.secho(
+                        f"⚠️  ZIP for activity {activity_id} contains "
+                        f"{len(zip_files)} files: {zip_files}. "
+                        f"Using first: {zip_files[0]!r}.",
+                        fg="yellow",
+                    )
+
+                inner_name = zip_files[0]
+                content = zip_ref.read(inner_name)
+
+        except zipfile.BadZipFile:
+            # Not a ZIP — probe the raw bytes directly.
+            content = raw_data
+
+        file_ext = _detect_format_from_magic(content)
+
+        if file_ext is not None:
+            if file_ext != "fit":
+                # Non-FIT format: log so we can learn Garmin's conventions.
+                click.secho(
+                    f"⚠️  Activity {activity_id}: detected '{file_ext}' format "
+                    f"(inner file: {inner_name!r}). "
+                    f"File will be saved but not processed.",
+                    fg="yellow",
+                )
+            return file_ext, content
+
+        # Magic bytes inconclusive — try the inner filename extension.
+        inner_ext = Path(inner_name).suffix.lower().lstrip(".")
+        if inner_ext in _KNOWN_ACTIVITY_EXTENSIONS:
+            click.secho(
+                f"⚠️  Activity {activity_id}: magic bytes inconclusive; "
+                f"using inner filename extension '.{inner_ext}' "
+                f"from {inner_name!r}.",
+                fg="yellow",
+            )
+            return inner_ext, content
+
+        # Completely unrecognised — preserve the file without processing it.
+        click.secho(
+            f"⚠️  Activity {activity_id}: unrecognised file format "
+            f"(inner file: {inner_name!r}). Saving as '.bin' — "
+            f"file will not be processed.",
+            fg="yellow",
+        )
+        return "bin", content
+
     def extract_fit_activities(self) -> List[Path]:
         """
-        Extract FIT activity files from Garmin Connect.
+        Extract activity files from Garmin Connect.
 
-        This method always processes dates inclusively - both start_date and
+        This method always processes dates inclusively — both start_date and
         end_date are included in the extraction. The extract() function
         handles any exclusion logic before passing dates to the Extractor
-        class. Downloads binary FIT files with user ID, activity ID, and
-        activity start timestamp in filename.
+        class. Downloads activity files with user ID, activity ID, and
+        activity start timestamp in filename. The file extension reflects the
+        actual format detected from the downloaded content.
 
-        :return: List of saved FIT file paths.
+        :return: List of saved activity file paths.
         """
 
         click.echo(
-            f"Fetching activities and associated FIT data from Garmin "
-            f"Connect (start: {self.start_date}, end: {self.end_date} "
-            f"inclusive)..."
+            f"Fetching activities from Garmin Connect "
+            f"(start: {self.start_date}, end: {self.end_date} inclusive)..."
         )
 
         # Get list of activities, API is inclusive of both dates.
@@ -397,7 +518,7 @@ class GarminExtractor:
         for activity in activities:
             activity_id = activity["activityId"]
 
-            # Generate filename with local timezone date at noon for
+            # Generate timestamp with local timezone date at noon for
             # consistent batching with ACTIVITIES_LIST file. Uses same
             # midday timestamp approach as _save_garmin_data().
             activity_start = pendulum.parse(activity.get("startTimeLocal"))
@@ -406,38 +527,31 @@ class GarminExtractor:
                 hour=12, minute=0, second=0
             )
             timestamp = pendulum.instance(midday_dt, tz="UTC").to_iso8601_string()
-            filename = f"{self.user_id}_ACTIVITY_{activity_id}_{timestamp}.fit".replace(
-                ":", "-"
-            )
-            filepath = self.ingest_dir / filename
 
-            # Download FIT file.
-            fit_data = self.garmin_client.download_activity(
+            # Download activity file (ORIGINAL format = ZIP archive).
+            raw_data = self.garmin_client.download_activity(
                 activity_id,
                 dl_fmt=ActivityDownloadFormat.ORIGINAL,
             )
 
-            # Extract FIT file from ZIP archive.
-            try:
-                with zipfile.ZipFile(io.BytesIO(fit_data), "r") as zip_ref:
-                    # Get the first (and typically only) file from the ZIP.
-                    zip_files = zip_ref.namelist()
-                    if not zip_files:
-                        click.secho(
-                            f"Empty ZIP archive for activity {activity_id}.",
-                            fg="yellow",
-                        )
-                        continue
+            # Detect actual file format and extract content.
+            result = self._extract_activity_content(activity_id, raw_data)
+            if result is None:
+                continue
 
-                    # Extract the FIT file content.
-                    fit_file_content = zip_ref.read(zip_files[0])
-            except zipfile.BadZipFile:
-                # If it's not a ZIP file, use the data as-is (fallback).
-                fit_file_content = fit_data
+            file_ext, file_content = result
+
+            # Build filename using the detected extension.
+            filename = (
+                f"{self.user_id}_ACTIVITY_{activity_id}_{timestamp}.{file_ext}".replace(
+                    ":", "-"
+                )
+            )
+            filepath = self.ingest_dir / filename
 
             # Save to file.
             with open(filepath, "wb") as f:
-                f.write(fit_file_content)
+                f.write(file_content)
 
             file_size = filepath.stat().st_size / 1024  # KB.
             click.echo(f"Saved: {filename} ({file_size:.1f} KB).")
@@ -460,7 +574,7 @@ class GarminExtractor:
             time.sleep(0.1)
 
         click.echo(
-            f"FIT activity extraction complete: {len(downloaded_files)} "
+            f"Activity file extraction complete: {len(downloaded_files)} "
             f"files saved to {self.ingest_dir}."
         )
         return downloaded_files

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -11,7 +11,22 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from garmin_health_data.extractor import GarminExtractor, extract
+from garmin_health_data.extractor import (
+    GarminExtractor,
+    _detect_format_from_magic,
+    extract,
+)
+
+# Minimal valid FIT file header (14 bytes).
+# Bytes 8–11 are the ANT+ FIT protocol magic: b'.FIT'.
+_FIT_MAGIC = b"\x0e\x10\x00\x00\x00\x00\x00\x00.FIT\x00\x00"
+
+_TCX_CONTENT = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b"<TrainingCenterDatabase/>"
+)
+_GPX_CONTENT = b'<?xml version="1.0"?><gpx version="1.1"/>'
+_KML_CONTENT = b'<?xml version="1.0"?><kml/>'
 
 
 class TestExtractExerciseSets:
@@ -190,7 +205,7 @@ class TestExtractExerciseSets:
         # Create mock ZIP file.
         zip_buffer = io.BytesIO()
         with zipfile.ZipFile(zip_buffer, "w") as zip_file:
-            zip_file.writestr("activity.fit", b"FIT_DATA")
+            zip_file.writestr("activity.fit", _FIT_MAGIC)
         zip_buffer.seek(0)
         mock_garmin_client.download_activity.return_value = zip_buffer.getvalue()
 
@@ -254,7 +269,7 @@ class TestExtractExerciseSets:
         # Create mock ZIP file.
         zip_buffer = io.BytesIO()
         with zipfile.ZipFile(zip_buffer, "w") as zip_file:
-            zip_file.writestr("activity.fit", b"FIT_DATA")
+            zip_file.writestr("activity.fit", _FIT_MAGIC)
         zip_buffer.seek(0)
         mock_garmin_client.download_activity.return_value = zip_buffer.getvalue()
 
@@ -451,3 +466,297 @@ class TestExtractMultiAccount:
         result = extract(Path("/tmp/test"), "2025-01-01", "2025-01-03")
 
         assert result == {"garmin_files": 0, "activity_files": 0}
+
+
+def _make_zip(inner_filename: str, content: bytes) -> bytes:
+    """
+    Build an in-memory ZIP containing one file.
+
+    :param inner_filename: Name to give the file inside the ZIP.
+    :param content: Raw bytes for the inner file.
+    :return: ZIP archive bytes.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(inner_filename, content)
+    return buf.getvalue()
+
+
+class TestDetectFormatFromMagic:
+    """
+    Unit tests for ``_detect_format_from_magic``.
+    """
+
+    def test_fit_bytes_detected(self) -> None:
+        """
+        FIT magic at offset 8–11 returns 'fit'.
+
+        :return: None.
+        """
+        assert _detect_format_from_magic(_FIT_MAGIC) == "fit"
+
+    def test_tcx_detected(self) -> None:
+        """
+        XML containing TrainingCenterDatabase root element returns 'tcx'.
+
+        :return: None.
+        """
+        assert _detect_format_from_magic(_TCX_CONTENT) == "tcx"
+
+    def test_gpx_detected(self) -> None:
+        """
+        XML containing gpx root element returns 'gpx'.
+
+        :return: None.
+        """
+        assert _detect_format_from_magic(_GPX_CONTENT) == "gpx"
+
+    def test_kml_detected(self) -> None:
+        """
+        XML containing kml root element returns 'kml'.
+
+        :return: None.
+        """
+        assert _detect_format_from_magic(_KML_CONTENT) == "kml"
+
+    def test_unknown_returns_none(self) -> None:
+        """
+        Arbitrary bytes with no recognisable signature return None.
+
+        :return: None.
+        """
+        assert _detect_format_from_magic(b"SOME_RANDOM_BYTES") is None
+
+    def test_empty_bytes_returns_none(self) -> None:
+        """
+        Empty byte string returns None (no magic to inspect).
+
+        :return: None.
+        """
+        assert _detect_format_from_magic(b"") is None
+
+    def test_fit_magic_at_wrong_offset_not_detected(self) -> None:
+        """
+        b'.FIT' at offset 0 (not 8) must not be mistaken for a FIT file.
+
+        :return: None.
+        """
+        content = b".FIT" + b"\x00" * 20
+        assert _detect_format_from_magic(content) is None
+
+    def test_content_shorter_than_12_bytes_not_fit(self) -> None:
+        """
+        Content shorter than 12 bytes cannot satisfy the FIT offset check.
+
+        :return: None.
+        """
+        short = b"\x00" * 8 + b".FI"  # 11 bytes — one short
+        assert _detect_format_from_magic(short) is None
+
+
+class TestExtractActivityContent:
+    """
+    Unit tests for ``GarminExtractor._extract_activity_content``.
+    """
+
+    @pytest.fixture()
+    def extractor(self, tmp_path: Path) -> GarminExtractor:
+        """
+        Return a GarminExtractor instance pointed at a temp directory.
+
+        :param tmp_path: Pytest tmp_path fixture.
+        :return: GarminExtractor instance.
+        """
+        return GarminExtractor(
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 1),
+            ingest_dir=tmp_path,
+        )
+
+    def test_fit_zip_returns_fit_extension(self, extractor: GarminExtractor) -> None:
+        """
+        ZIP containing a FIT file returns ('fit', content).
+
+        :param extractor: GarminExtractor fixture.
+        :return: None.
+        """
+        raw = _make_zip("12345_ACTIVITY.fit", _FIT_MAGIC)
+        result = extractor._extract_activity_content(12345, raw)
+        assert result is not None
+        ext, content = result
+        assert ext == "fit"
+        assert content == _FIT_MAGIC
+
+    def test_tcx_zip_returns_tcx_extension(self, extractor: GarminExtractor) -> None:
+        """
+        ZIP containing a TCX file returns ('tcx', content).
+
+        :param extractor: GarminExtractor fixture.
+        :return: None.
+        """
+        raw = _make_zip("12345.tcx", _TCX_CONTENT)
+        result = extractor._extract_activity_content(12345, raw)
+        assert result is not None
+        ext, content = result
+        assert ext == "tcx"
+        assert content == _TCX_CONTENT
+
+    def test_gpx_zip_returns_gpx_extension(self, extractor: GarminExtractor) -> None:
+        """
+        ZIP containing a GPX file returns ('gpx', content).
+
+        :param extractor: GarminExtractor fixture.
+        :return: None.
+        """
+        raw = _make_zip("12345.gpx", _GPX_CONTENT)
+        result = extractor._extract_activity_content(12345, raw)
+        assert result is not None
+        ext, content = result
+        assert ext == "gpx"
+
+    def test_empty_zip_returns_none(self, extractor: GarminExtractor) -> None:
+        """
+        Empty ZIP archive returns None (activity is skipped).
+
+        :param extractor: GarminExtractor fixture.
+        :return: None.
+        """
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w"):
+            pass
+        result = extractor._extract_activity_content(12345, buf.getvalue())
+        assert result is None
+
+    def test_non_zip_raw_fit_bytes(self, extractor: GarminExtractor) -> None:
+        """
+        Non-ZIP bytes that are a valid FIT file are returned as 'fit'.
+
+        :param extractor: GarminExtractor fixture.
+        :return: None.
+        """
+        result = extractor._extract_activity_content(12345, _FIT_MAGIC)
+        assert result is not None
+        ext, content = result
+        assert ext == "fit"
+        assert content == _FIT_MAGIC
+
+    def test_unknown_magic_falls_back_to_inner_filename_extension(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        When magic bytes are inconclusive, the inner filename extension is used.
+
+        :param extractor: GarminExtractor fixture.
+        :return: None.
+        """
+        unknown_content = b"UNKNOWN_FORMAT_BYTES"
+        raw = _make_zip("activity.tcx", unknown_content)
+        result = extractor._extract_activity_content(12345, raw)
+        assert result is not None
+        ext, content = result
+        assert ext == "tcx"
+        assert content == unknown_content
+
+    def test_unknown_magic_and_unknown_extension_returns_bin(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        Completely unrecognised format is saved as '.bin'.
+
+        :param extractor: GarminExtractor fixture.
+        :return: None.
+        """
+        unknown_content = b"MYSTERY_BYTES"
+        raw = _make_zip("activity.xyz", unknown_content)
+        result = extractor._extract_activity_content(12345, raw)
+        assert result is not None
+        ext, _ = result
+        assert ext == "bin"
+
+
+@patch("garmin_health_data.extractor.time.sleep")
+class TestExtractFitActivitiesFormat:
+    """
+    Integration tests verifying that extract_fit_activities saves files
+    with the correct extension based on detected content format.
+    """
+
+    @pytest.fixture()
+    def extractor(self, tmp_path: Path) -> GarminExtractor:
+        """
+        Return a GarminExtractor pointed at a temp directory.
+
+        :param tmp_path: Pytest tmp_path fixture.
+        :return: GarminExtractor instance.
+        """
+        inst = GarminExtractor(
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 1),
+            ingest_dir=tmp_path,
+        )
+        inst.user_id = "123456789"
+        return inst
+
+    def _activities(self, activity_id: str = "99999") -> list:
+        """
+        Return a minimal activity list fixture.
+
+        :param activity_id: Activity ID string.
+        :return: List with one activity dict.
+        """
+        return [
+            {
+                "activityId": activity_id,
+                "startTimeLocal": "2025-01-01T10:00:00.000",
+                "activityType": {"typeId": 1, "typeKey": "running"},
+            }
+        ]
+
+    def test_fit_content_saved_as_fit(
+        self, _mock_sleep, extractor: GarminExtractor, tmp_path: Path
+    ) -> None:
+        """
+        FIT content inside ZIP is saved with a .fit extension.
+
+        :param _mock_sleep: Patched sleep.
+        :param extractor: GarminExtractor fixture.
+        :param tmp_path: Pytest tmp_path fixture.
+        :return: None.
+        """
+        mock_client = MagicMock()
+        mock_client.get_activities_by_date.return_value = self._activities()
+        mock_client.download_activity.return_value = _make_zip(
+            "99999_ACTIVITY.fit", _FIT_MAGIC
+        )
+        extractor.garmin_client = mock_client
+
+        paths = extractor.extract_fit_activities()
+
+        assert len(paths) == 1
+        assert paths[0].suffix == ".fit"
+        assert len(list(tmp_path.glob("*.fit"))) == 1
+
+    def test_tcx_content_saved_as_tcx(
+        self, _mock_sleep, extractor: GarminExtractor, tmp_path: Path
+    ) -> None:
+        """
+        TCX content inside ZIP is saved with a .tcx extension, not .fit.
+
+        :param _mock_sleep: Patched sleep.
+        :param extractor: GarminExtractor fixture.
+        :param tmp_path: Pytest tmp_path fixture.
+        :return: None.
+        """
+        mock_client = MagicMock()
+        mock_client.get_activities_by_date.return_value = self._activities()
+        mock_client.download_activity.return_value = _make_zip(
+            "99999.tcx", _TCX_CONTENT
+        )
+        extractor.garmin_client = mock_client
+
+        paths = extractor.extract_fit_activities()
+
+        assert len(paths) == 1
+        assert paths[0].suffix == ".tcx"
+        assert len(list(tmp_path.glob("*.fit"))) == 0
+        assert len(list(tmp_path.glob("*.tcx"))) == 1


### PR DESCRIPTION
fix: detect activity file format from magic bytes instead of assuming a .fit file and provide graceful bypass

## Description

This fix was motivated by activity downloads that include files other than .FIT file extensions, consisting mainly of .TCX files uploaded from other recording software to Garmin Connect and becoming part of the overall user's activity record. The file processor would hard-crash the application upon coming across an activity file that was not in .FIT format. This was because the program hard-coded the .FIT extension and didn't have file type checking to see what type of file we have.

This fix implements basic file type checking for typical activity formats (ANT+ FIT protocol header at byte offset 8–11; XML root
  element for TCX/GPX/KML) and gracefully continues if the file format is not detected to be a FIT file. Future improvements could include processing non-FIT files for activity details as well, but that has been deliberately left out of this fix.

A secondary guard was added to the CLI to skip `process_file_set` entirely when all files in a timestamp group are of
  unrecognized types, preventing a crash in `_parse_filename` when no processable files exist.

Tests have been updated to include checks for different file types.

Portions of this code were generated and tested using generative AI and were reviewed and tested by the author.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Test update

## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests pass (`make test`)

## Testing

Existing tests updated: two mocks previously used b"FIT_DATA" as placeholder content. These were replaced with a real
  14-byte ANT+ FIT header so magic-byte detection works correctly against them.

Real-world verification against a live Garmin Connect account:
* Activity ZIP contained 689551990_UNKNOWN.tcx; detected as tcx via magic bytes, saved as .tcx with a clear warning, all JSON data types processed normally. Previously crashed.
* Standard modern FIT activity; detected as fit, saved as .fit, processed through the full pipeline (93,718 time-series records, 135 splits, 360 laps, 4,739 GPS path points). No regressions.

**Test Configuration**:
- Python version: 3.13.12
- Operating System: Windows 11
- Garmin Connect account type: Standard account

## Additional Notes

The three-tier fallback chain in `_extract_activity_content` is intentionally conservative:

1. Magic bytes: format-definitive, independent of whatever Garmin names the file inside the ZIP.
2. Inner filename extension: used only when magic bytes are inconclusive and the extension is in the known-extensions
 set (fit, tcx, gpx, kml). Discovered that Garmin names TCX inner files `{activity_id}_UNKNOWN.tcx`, which would have
been sufficient on its own but relying on a naming convention we only observed once felt fragile.
3. .bin: completely unrecognized content is preserved on disk but excluded from processing, with a clear warning.

TCX processing itself (extracting time-series and lap data from the XML) is out of scope for this PR. The activity
metadata row is still inserted correctly via ACTIVITIES_LIST, so the record is not lost, only the detailed
time-series data is absent for TCX-format activities.

