### PR TITLE
Migrate legacy SQLAlchemy 1.4 patterns to 2.0 style

### DIFF
--- a/garmin_health_data/db.py
+++ b/garmin_health_data/db.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import click
-from sqlalchemy import create_engine, func
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session
 
 # Handle importlib.resources for different Python versions
 if sys.version_info >= (3, 9):
@@ -98,8 +98,7 @@ def get_session(db_path: str = "garmin_data.db"):
     :yield: SQLAlchemy Session.
     """
     engine = get_engine(db_path)
-    SessionLocal = sessionmaker(bind=engine)
-    session = SessionLocal()
+    session = Session(engine)
 
     try:
         yield session
@@ -143,43 +142,45 @@ def get_last_update_dates(db_path: str = "garmin_data.db") -> Dict[str, Optional
         dates = {}
 
         # Sleep data.
-        last_sleep = session.query(func.max(Sleep.start_ts)).scalar()
+        last_sleep = session.execute(select(func.max(Sleep.start_ts))).scalar()
         dates["sleep"] = last_sleep.date() if last_sleep else None
 
         # Heart rate.
-        last_hr = session.query(func.max(HeartRate.timestamp)).scalar()
+        last_hr = session.execute(select(func.max(HeartRate.timestamp))).scalar()
         dates["heart_rate"] = last_hr.date() if last_hr else None
 
         # Activities.
-        last_activity = session.query(func.max(Activity.start_ts)).scalar()
+        last_activity = session.execute(select(func.max(Activity.start_ts))).scalar()
         dates["activity"] = last_activity.date() if last_activity else None
 
         # Stress.
-        last_stress = session.query(func.max(Stress.timestamp)).scalar()
+        last_stress = session.execute(select(func.max(Stress.timestamp))).scalar()
         dates["stress"] = last_stress.date() if last_stress else None
 
         # Body battery.
-        last_bb = session.query(func.max(BodyBattery.timestamp)).scalar()
+        last_bb = session.execute(select(func.max(BodyBattery.timestamp))).scalar()
         dates["body_battery"] = last_bb.date() if last_bb else None
 
         # Steps.
-        last_steps = session.query(func.max(Steps.timestamp)).scalar()
+        last_steps = session.execute(select(func.max(Steps.timestamp))).scalar()
         dates["steps"] = last_steps.date() if last_steps else None
 
         # Respiration.
-        last_resp = session.query(func.max(Respiration.timestamp)).scalar()
+        last_resp = session.execute(select(func.max(Respiration.timestamp))).scalar()
         dates["respiration"] = last_resp.date() if last_resp else None
 
         # Floors.
-        last_floors = session.query(func.max(Floors.timestamp)).scalar()
+        last_floors = session.execute(select(func.max(Floors.timestamp))).scalar()
         dates["floors"] = last_floors.date() if last_floors else None
 
         # Intensity minutes.
-        last_im = session.query(func.max(IntensityMinutes.timestamp)).scalar()
+        last_im = session.execute(select(func.max(IntensityMinutes.timestamp))).scalar()
         dates["intensity_minutes"] = last_im.date() if last_im else None
 
         # Training readiness.
-        last_tr = session.query(func.max(TrainingReadiness.timestamp)).scalar()
+        last_tr = session.execute(
+            select(func.max(TrainingReadiness.timestamp))
+        ).scalar()
         dates["training_readiness"] = last_tr.date() if last_tr else None
 
         return dates
@@ -211,19 +212,27 @@ def get_record_counts(db_path: str = "garmin_data.db") -> Dict[str, int]:
     with get_session(db_path) as session:
         counts = {}
 
-        counts["users"] = session.query(func.count(User.user_id)).scalar()
-        counts["activities"] = session.query(func.count(Activity.activity_id)).scalar()
-        counts["sleep_sessions"] = session.query(func.count(Sleep.sleep_id)).scalar()
-        counts["heart_rate_readings"] = session.query(
-            func.count(HeartRate.timestamp)
+        counts["users"] = session.execute(select(func.count(User.user_id))).scalar()
+        counts["activities"] = session.execute(
+            select(func.count(Activity.activity_id))
         ).scalar()
-        counts["stress_readings"] = session.query(func.count(Stress.timestamp)).scalar()
-        counts["body_battery_readings"] = session.query(
-            func.count(BodyBattery.timestamp)
+        counts["sleep_sessions"] = session.execute(
+            select(func.count(Sleep.sleep_id))
         ).scalar()
-        counts["step_readings"] = session.query(func.count(Steps.timestamp)).scalar()
-        counts["respiration_readings"] = session.query(
-            func.count(Respiration.timestamp)
+        counts["heart_rate_readings"] = session.execute(
+            select(func.count(HeartRate.timestamp))
+        ).scalar()
+        counts["stress_readings"] = session.execute(
+            select(func.count(Stress.timestamp))
+        ).scalar()
+        counts["body_battery_readings"] = session.execute(
+            select(func.count(BodyBattery.timestamp))
+        ).scalar()
+        counts["step_readings"] = session.execute(
+            select(func.count(Steps.timestamp))
+        ).scalar()
+        counts["respiration_readings"] = session.execute(
+            select(func.count(Respiration.timestamp))
         ).scalar()
 
         return counts

--- a/garmin_health_data/models.py
+++ b/garmin_health_data/models.py
@@ -21,12 +21,16 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import text
 
+
 # Base class for all models.
-Base = declarative_base()
+class Base(DeclarativeBase):
+    """
+    Base class for all ORM models.
+    """
 
 
 class InsertBase:

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import fitdecode
-from sqlalchemy import and_, text
+from sqlalchemy import and_, delete, insert, select, text
 from sqlalchemy.orm import Session
 
 from garmin_health_data.processor_helpers import Processor
@@ -311,7 +311,11 @@ class GarminProcessor(Processor):
         """
 
         # Check if user exists in user table.
-        existing_user = session.query(User).filter(User.user_id == int(user_id)).first()
+        existing_user = (
+            session.execute(select(User).where(User.user_id == int(user_id)))
+            .scalars()
+            .first()
+        )
 
         if not existing_user:
             # Create minimal user record with conflict handling.
@@ -362,7 +366,9 @@ class GarminProcessor(Processor):
         # Update user table with demographics if needed.
         if self.must_update_user:
             user_record = (
-                session.query(User).filter(User.user_id == int(self.user_id)).first()
+                session.execute(select(User).where(User.user_id == int(self.user_id)))
+                .scalars()
+                .first()
             )
             if user_record:
                 user_record.full_name = full_name
@@ -371,8 +377,15 @@ class GarminProcessor(Processor):
 
         # Get latest user profile.
         latest_profile = (
-            session.query(UserProfile)
-            .filter(and_(UserProfile.user_id == int(self.user_id), UserProfile.latest))
+            session.execute(
+                select(UserProfile).where(
+                    and_(
+                        UserProfile.user_id == int(self.user_id),
+                        UserProfile.latest,
+                    )
+                )
+            )
+            .scalars()
             .first()
         )
 
@@ -883,7 +896,9 @@ class GarminProcessor(Processor):
         # Always delete existing rows for reprocessing (cleans
         # stale data even when the activity no longer has exercise
         # sets).
-        session.query(StrengthExercise).filter_by(activity_id=activity_id).delete()
+        session.execute(
+            delete(StrengthExercise).where(StrengthExercise.activity_id == activity_id)
+        )
 
         if not summarized_sets:
             click.echo("No summarized exercise sets found for strength " "activity.")
@@ -950,7 +965,9 @@ class GarminProcessor(Processor):
         # Always delete existing rows for reprocessing (cleans
         # stale data even when the activity no longer has exercise
         # sets).
-        session.query(StrengthSet).filter_by(activity_id=activity_id).delete()
+        session.execute(
+            delete(StrengthSet).where(StrengthSet.activity_id == activity_id)
+        )
 
         if not exercise_sets:
             click.echo(
@@ -2342,8 +2359,10 @@ class GarminProcessor(Processor):
             else:
                 # Check if activity exists (warning only, not blocking).
                 activity_exists = (
-                    session.query(Activity)
-                    .filter(Activity.activity_id == activity_id)
+                    session.execute(
+                        select(Activity).where(Activity.activity_id == activity_id)
+                    )
+                    .scalars()
                     .first()
                     is not None
                 )
@@ -2363,14 +2382,16 @@ class GarminProcessor(Processor):
             # Find all PersonalRecord rows with `latest`=True and same `type_id` for
             # this user.
             latest_prs = (
-                session.query(PersonalRecord)
-                .filter(
-                    and_(
-                        PersonalRecord.user_id == int(self.user_id),
-                        PersonalRecord.type_id == type_id,
-                        PersonalRecord.latest,
+                session.execute(
+                    select(PersonalRecord).where(
+                        and_(
+                            PersonalRecord.user_id == int(self.user_id),
+                            PersonalRecord.type_id == type_id,
+                            PersonalRecord.latest,
+                        )
                     )
                 )
+                .scalars()
                 .all()
             )
 
@@ -2438,13 +2459,15 @@ class GarminProcessor(Processor):
 
         # Find all race predictions with `latest`=True for this user.
         latest_race_predictions = (
-            session.query(RacePredictions)
-            .filter(
-                and_(
-                    RacePredictions.user_id == int(self.user_id),
-                    RacePredictions.latest,
+            session.execute(
+                select(RacePredictions).where(
+                    and_(
+                        RacePredictions.user_id == int(self.user_id),
+                        RacePredictions.latest,
+                    )
                 )
             )
+            .scalars()
             .all()
         )
 
@@ -2509,7 +2532,9 @@ class GarminProcessor(Processor):
 
         # Verify activity exists (FIT file requires a parent activity record).
         existing_activity = (
-            session.query(Activity).filter(Activity.activity_id == activity_id).first()
+            session.execute(select(Activity).where(Activity.activity_id == activity_id))
+            .scalars()
+            .first()
         )
 
         if not existing_activity:
@@ -2682,22 +2707,45 @@ class GarminProcessor(Processor):
 
         # Delete existing FIT metric rows for this activity before re-inserting.
         # This handles added/removed laps, splits, or records between reprocesses.
-        session.query(ActivityTsMetric).filter_by(activity_id=activity_id).delete(
-            synchronize_session=False
+        session.execute(
+            delete(ActivityTsMetric)
+            .where(ActivityTsMetric.activity_id == activity_id)
+            .execution_options(synchronize_session=False)
         )
-        session.query(ActivitySplitMetric).filter_by(activity_id=activity_id).delete(
-            synchronize_session=False
+        session.execute(
+            delete(ActivitySplitMetric)
+            .where(ActivitySplitMetric.activity_id == activity_id)
+            .execution_options(synchronize_session=False)
         )
-        session.query(ActivityLapMetric).filter_by(activity_id=activity_id).delete(
-            synchronize_session=False
+        session.execute(
+            delete(ActivityLapMetric)
+            .where(ActivityLapMetric.activity_id == activity_id)
+            .execution_options(synchronize_session=False)
         )
-        session.query(ActivityPath).filter_by(activity_id=activity_id).delete(
-            synchronize_session=False
+        session.execute(
+            delete(ActivityPath)
+            .where(ActivityPath.activity_id == activity_id)
+            .execution_options(synchronize_session=False)
         )
 
-        # Bulk insert all metrics.
+        # Core-level bulk insert for FIT metrics. Uses insert() instead
+        # of add_all() to bypass the ORM identity map, matching the
+        # original bulk_save_objects() intent: the preceding deletes use
+        # synchronize_session=False, so stale instances may remain in the
+        # map. Core insert also avoids the RETURNING sentinel mismatch
+        # that SQLite triggers with DateTime(timezone=True) composite PKs.
         if ts_metrics:
-            session.bulk_save_objects(ts_metrics)
+            session.execute(
+                insert(ActivityTsMetric),
+                [
+                    {
+                        c.key: getattr(m, c.key)
+                        for c in ActivityTsMetric.__table__.columns
+                        if c.server_default is None
+                    }
+                    for m in ts_metrics
+                ],
+            )
             click.echo(f"Processed {len(ts_metrics)} time-series records.")
         else:
             click.secho("⚠️ No time-series data found.", fg="yellow")
@@ -2705,13 +2753,33 @@ class GarminProcessor(Processor):
         existing_activity.ts_data_available = bool(ts_metrics)
 
         if split_metrics:
-            session.bulk_save_objects(split_metrics)
+            session.execute(
+                insert(ActivitySplitMetric),
+                [
+                    {
+                        c.key: getattr(m, c.key)
+                        for c in ActivitySplitMetric.__table__.columns
+                        if c.server_default is None
+                    }
+                    for m in split_metrics
+                ],
+            )
             click.echo(f"Processed {len(split_metrics)} split records.")
         else:
             click.secho("⚠️ No split data found.", fg="yellow")
 
         if lap_metrics:
-            session.bulk_save_objects(lap_metrics)
+            session.execute(
+                insert(ActivityLapMetric),
+                [
+                    {
+                        c.key: getattr(m, c.key)
+                        for c in ActivityLapMetric.__table__.columns
+                        if c.server_default is None
+                    }
+                    for m in lap_metrics
+                ],
+            )
             click.echo(f"Processed {len(lap_metrics)} lap records.")
         else:
             click.secho("⚠️ No lap data found.", fg="yellow")
@@ -2731,19 +2799,15 @@ class GarminProcessor(Processor):
                 for _, lon_semi, lat_semi in gps_records
             ]
 
-            # Use bulk_save_objects to bypass the ORM identity map, matching
-            # the sibling FIT-table insert pattern above. session.add() would
-            # collide with the stale identity-mapped instance left over from
-            # the delete+reinsert above (the sibling deletes use
-            # synchronize_session=False).
-            session.bulk_save_objects(
+            session.execute(
+                insert(ActivityPath),
                 [
-                    ActivityPath(
-                        activity_id=activity_id,
-                        path_json=path_coords,
-                        point_count=len(path_coords),
-                    )
-                ]
+                    {
+                        "activity_id": activity_id,
+                        "path_json": path_coords,
+                        "point_count": len(path_coords),
+                    }
+                ],
             )
             click.echo(f"Processed {len(path_coords)} GPS path points.")
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session
 
 from garmin_health_data.models import Base
 
@@ -52,8 +52,7 @@ def db_session(db_engine: Engine) -> Generator[Session, None, None]:
     :param db_engine: SQLAlchemy engine fixture.
     :return: SQLAlchemy session instance.
     """
-    SessionLocal = sessionmaker(bind=db_engine)
-    session = SessionLocal()
+    session = Session(db_engine)
     yield session
     session.close()
 

--- a/tests/test_db_extended.py
+++ b/tests/test_db_extended.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
@@ -66,7 +67,11 @@ class TestGetSession:
 
         # Verify the record was committed.
         with get_session(temp_db_path) as session:
-            result = session.query(User).filter_by(user_id=12345).first()
+            result = (
+                session.execute(select(User).where(User.user_id == 12345))
+                .scalars()
+                .first()
+            )
             assert result is not None
             assert result.full_name == "Test User"
 
@@ -86,7 +91,11 @@ class TestGetSession:
 
         # Verify the record was not committed.
         with get_session(temp_db_path) as session:
-            result = session.query(User).filter_by(user_id=12345).first()
+            result = (
+                session.execute(select(User).where(User.user_id == 12345))
+                .scalars()
+                .first()
+            )
             assert result is None
 
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import fitdecode
 import pytest
+from sqlalchemy import func, insert, select
 from sqlalchemy.orm import Session
 
 from garmin_health_data.models import (
@@ -138,7 +139,11 @@ def _seed_activity(
     session.commit()
 
     # Set ts_data_available after upsert (bypasses column exclusion).
-    persisted = session.query(Activity).filter_by(activity_id=activity_id).first()
+    persisted = (
+        session.execute(select(Activity).where(Activity.activity_id == activity_id))
+        .scalars()
+        .first()
+    )
     persisted.ts_data_available = ts_data_available
     session.commit()
 
@@ -198,10 +203,18 @@ class TestProcessFitFile:
 
         db_session.commit()
 
-        assert db_session.query(ActivityTsMetric).count() == 2
-        assert db_session.query(ActivityLapMetric).count() == 2
+        assert (
+            db_session.scalar(select(func.count()).select_from(ActivityTsMetric)) == 2
+        )
+        assert (
+            db_session.scalar(select(func.count()).select_from(ActivityLapMetric)) == 2
+        )
 
-        refreshed = db_session.query(Activity).filter_by(activity_id=12345).first()
+        refreshed = (
+            db_session.execute(select(Activity).where(Activity.activity_id == 12345))
+            .scalars()
+            .first()
+        )
         assert refreshed.ts_data_available is True
 
     def test_process_fit_file_reprocessing(self, db_session: Session):
@@ -212,32 +225,55 @@ class TestProcessFitFile:
 
         # Simulate pre-existing metrics from a previous run.
         old_ts = datetime(2024, 1, 1, 8, 0, 0, tzinfo=timezone.utc)
-        db_session.bulk_save_objects(
+        # Use core insert to bypass RETURNING sentinel mismatch
+        # with DateTime(timezone=True) composite PKs on SQLite.
+        db_session.execute(
+            insert(ActivityTsMetric),
             [
-                ActivityTsMetric(
-                    activity_id=12345,
-                    timestamp=old_ts,
-                    name="old_metric",
-                    value=1.0,
-                ),
-                ActivityLapMetric(
-                    activity_id=12345,
-                    lap_idx=1,
-                    name="old_lap",
-                    value=100.0,
-                ),
-                ActivitySplitMetric(
-                    activity_id=12345,
-                    split_idx=1,
-                    name="old_split",
-                    value=200.0,
-                ),
-            ]
+                {
+                    "activity_id": 12345,
+                    "timestamp": old_ts,
+                    "name": "old_metric",
+                    "value": 1.0,
+                    "units": None,
+                },
+            ],
+        )
+        db_session.execute(
+            insert(ActivityLapMetric),
+            [
+                {
+                    "activity_id": 12345,
+                    "lap_idx": 1,
+                    "name": "old_lap",
+                    "value": 100.0,
+                    "units": None,
+                },
+            ],
+        )
+        db_session.execute(
+            insert(ActivitySplitMetric),
+            [
+                {
+                    "activity_id": 12345,
+                    "split_idx": 1,
+                    "name": "old_split",
+                    "value": 200.0,
+                    "units": None,
+                },
+            ],
         )
         db_session.commit()
-        assert db_session.query(ActivityTsMetric).count() == 1
-        assert db_session.query(ActivityLapMetric).count() == 1
-        assert db_session.query(ActivitySplitMetric).count() == 1
+        assert (
+            db_session.scalar(select(func.count()).select_from(ActivityTsMetric)) == 1
+        )
+        assert (
+            db_session.scalar(select(func.count()).select_from(ActivityLapMetric)) == 1
+        )
+        assert (
+            db_session.scalar(select(func.count()).select_from(ActivitySplitMetric))
+            == 1
+        )
 
         # New FIT data with different metrics.
         new_ts = datetime(2024, 1, 1, 8, 0, 5, tzinfo=timezone.utc)
@@ -264,17 +300,20 @@ class TestProcessFitFile:
         db_session.commit()
 
         # Old rows deleted, new rows inserted.
-        ts_rows = db_session.query(ActivityTsMetric).all()
+        ts_rows = db_session.execute(select(ActivityTsMetric)).scalars().all()
         assert len(ts_rows) == 1
         assert ts_rows[0].name == "heart_rate"
         assert ts_rows[0].value == 160.0
 
-        lap_rows = db_session.query(ActivityLapMetric).all()
+        lap_rows = db_session.execute(select(ActivityLapMetric)).scalars().all()
         assert len(lap_rows) == 1
         assert lap_rows[0].name == "total_elapsed_time"
 
         # Old splits deleted (no new splits in this FIT data).
-        assert db_session.query(ActivitySplitMetric).count() == 0
+        assert (
+            db_session.scalar(select(func.count()).select_from(ActivitySplitMetric))
+            == 0
+        )
 
     def test_process_fit_file_laps_only(self, db_session: Session):
         """
@@ -298,10 +337,18 @@ class TestProcessFitFile:
 
         db_session.commit()
 
-        assert db_session.query(ActivityTsMetric).count() == 0
-        assert db_session.query(ActivityLapMetric).count() == 2
+        assert (
+            db_session.scalar(select(func.count()).select_from(ActivityTsMetric)) == 0
+        )
+        assert (
+            db_session.scalar(select(func.count()).select_from(ActivityLapMetric)) == 2
+        )
 
-        refreshed = db_session.query(Activity).filter_by(activity_id=12345).first()
+        refreshed = (
+            db_session.execute(select(Activity).where(Activity.activity_id == 12345))
+            .scalars()
+            .first()
+        )
         # No record frames means ts_data_available stays False.
         assert refreshed.ts_data_available is False
 
@@ -381,7 +428,7 @@ class TestProcessFitFile:
 
         db_session.commit()
 
-        paths = db_session.query(ActivityPath).all()
+        paths = db_session.execute(select(ActivityPath)).scalars().all()
         assert len(paths) == 1
         path = paths[0]
         assert path.activity_id == 12345
@@ -421,9 +468,11 @@ class TestProcessFitFile:
         db_session.commit()
 
         # Non-GPS ts metrics still inserted.
-        assert db_session.query(ActivityTsMetric).count() == 2
+        assert (
+            db_session.scalar(select(func.count()).select_from(ActivityTsMetric)) == 2
+        )
         # No activity_path row.
-        assert db_session.query(ActivityPath).count() == 0
+        assert db_session.scalar(select(func.count()).select_from(ActivityPath)) == 0
 
     def test_process_fit_file_partial_gps_filtered(self, db_session: Session):
         """
@@ -463,7 +512,7 @@ class TestProcessFitFile:
 
         db_session.commit()
 
-        paths = db_session.query(ActivityPath).all()
+        paths = db_session.execute(select(ActivityPath)).scalars().all()
         assert len(paths) == 1
         path = paths[0]
         assert path.point_count == 1
@@ -512,7 +561,7 @@ class TestProcessFitFile:
 
         run_with_frames(run1_frames)
 
-        paths = db_session.query(ActivityPath).all()
+        paths = db_session.execute(select(ActivityPath)).scalars().all()
         assert len(paths) == 1
         assert paths[0].point_count == 2
 
@@ -545,7 +594,7 @@ class TestProcessFitFile:
         ]
         run_with_frames(run2_frames)
 
-        paths = db_session.query(ActivityPath).all()
+        paths = db_session.execute(select(ActivityPath)).scalars().all()
         assert len(paths) == 1
         assert paths[0].point_count == 3
 
@@ -561,7 +610,7 @@ class TestProcessFitFile:
         ]
         run_with_frames(run3_frames)
 
-        assert db_session.query(ActivityPath).count() == 0
+        assert db_session.scalar(select(func.count()).select_from(ActivityPath)) == 0
 
 
 # --- Activity base upsert tests --------------------------------------------
@@ -617,7 +666,11 @@ class TestActivityBaseUpsert:
         )
         db_session.commit()
 
-        refreshed = db_session.query(Activity).filter_by(activity_id=12345).first()
+        refreshed = (
+            db_session.execute(select(Activity).where(Activity.activity_id == 12345))
+            .scalars()
+            .first()
+        )
         assert refreshed.activity_name == "Renamed Run"
         # ts_data_available preserved despite upsert.
         assert refreshed.ts_data_available is True
@@ -628,7 +681,11 @@ class TestActivityBaseUpsert:
         """
         _seed_activity(db_session)
 
-        original = db_session.query(Activity).filter_by(activity_id=12345).first()
+        original = (
+            db_session.execute(select(Activity).where(Activity.activity_id == 12345))
+            .scalars()
+            .first()
+        )
         original_create_ts = original.create_ts
 
         update_columns = [
@@ -667,7 +724,11 @@ class TestActivityBaseUpsert:
         )
         db_session.commit()
 
-        refreshed = db_session.query(Activity).filter_by(activity_id=12345).first()
+        refreshed = (
+            db_session.execute(select(Activity).where(Activity.activity_id == 12345))
+            .scalars()
+            .first()
+        )
         assert refreshed.activity_name == "Updated Name"
         assert refreshed.create_ts == original_create_ts
 
@@ -1007,12 +1068,13 @@ class TestProcessStrengthMetrics:
         assert "totalReps" not in activity_data
         assert "otherField" in activity_data
 
-        # Assert - delete was called for reprocessing.
-        mock_session.query.assert_called_with(StrengthExercise)
-        filter_call = mock_session.query.return_value.filter_by
-        filter_call.assert_called_with(activity_id=activity_id)
-        delete_call = filter_call.return_value
-        delete_call.delete.assert_called_once()
+        # Verify delete was called via session.execute.
+        delete_calls = [
+            call
+            for call in mock_session.execute.call_args_list
+            if hasattr(call.args[0], "is_delete") and call.args[0].is_delete
+        ]
+        assert len(delete_calls) >= 1
 
         # Assert - records were added.
         mock_session.add_all.assert_called_once()
@@ -1095,8 +1157,13 @@ class TestProcessStrengthMetrics:
         assert "activeSets" not in activity_data
         assert "totalReps" not in activity_data
 
-        # Assert - delete was called (cleans stale data).
-        mock_session.query.assert_called_with(StrengthExercise)
+        # Verify delete was called via session.execute.
+        delete_calls = [
+            call
+            for call in mock_session.execute.call_args_list
+            if hasattr(call.args[0], "is_delete") and call.args[0].is_delete
+        ]
+        assert len(delete_calls) >= 1
 
         # Assert - no insert since sets are empty.
         mock_session.add_all.assert_not_called()
@@ -1179,10 +1246,13 @@ class TestProcessExerciseSets:
         # Act.
         processor._process_exercise_sets(file_path, mock_session)
 
-        # Assert - delete was called for reprocessing.
-        mock_session.query.assert_called_with(StrengthSet)
-        filter_call = mock_session.query.return_value.filter_by
-        filter_call.assert_called_with(activity_id=22320029355)
+        # Verify delete was called via session.execute.
+        delete_calls = [
+            call
+            for call in mock_session.execute.call_args_list
+            if hasattr(call.args[0], "is_delete") and call.args[0].is_delete
+        ]
+        assert len(delete_calls) >= 1
 
         # Assert - records were added.
         mock_session.add_all.assert_called_once()
@@ -1280,9 +1350,13 @@ class TestProcessExerciseSets:
         # Act.
         processor._process_exercise_sets(file_path, mock_session)
 
-        # Assert - delete called, no inserts.
-        filter_call = mock_session.query.return_value.filter_by.return_value
-        filter_call.delete.assert_called()
+        # Verify delete was called via session.execute.
+        delete_calls = [
+            call
+            for call in mock_session.execute.call_args_list
+            if hasattr(call.args[0], "is_delete") and call.args[0].is_delete
+        ]
+        assert len(delete_calls) >= 1
         mock_session.add_all.assert_not_called()
 
 

--- a/tests/test_processor_helpers.py
+++ b/tests/test_processor_helpers.py
@@ -11,6 +11,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 import pytest
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from garmin_health_data.db import get_engine
@@ -72,7 +73,7 @@ class TestUpsertModelInstances:
             session.commit()
 
             assert len(result) == 1
-            count = session.query(User).count()
+            count = session.scalar(select(func.count()).select_from(User))
             assert count == 1
 
     def test_bulk_insert_multiple_records(self, temp_db):
@@ -95,7 +96,7 @@ class TestUpsertModelInstances:
             session.commit()
 
             assert len(result) == 100
-            count = session.query(User).count()
+            count = session.scalar(select(func.count()).select_from(User))
             assert count == 100
 
     def test_bulk_update_on_conflict(self, temp_db):
@@ -137,11 +138,15 @@ class TestUpsertModelInstances:
             session.commit()
 
             # Verify updates.
-            user1 = session.query(User).filter(User.user_id == 1).first()
-            user2 = session.query(User).filter(User.user_id == 2).first()
+            user1 = (
+                session.execute(select(User).where(User.user_id == 1)).scalars().first()
+            )
+            user2 = (
+                session.execute(select(User).where(User.user_id == 2)).scalars().first()
+            )
             assert user1.full_name == "Updated User 1"
             assert user2.full_name == "Updated User 2"
-            assert session.query(User).count() == 2
+            assert session.scalar(select(func.count()).select_from(User)) == 2
 
     def test_insert_ignore_on_conflict(self, temp_db):
         """
@@ -182,11 +187,15 @@ class TestUpsertModelInstances:
             session.commit()
 
             # Verify user 1 was NOT updated, user 3 was inserted.
-            user1 = session.query(User).filter(User.user_id == 1).first()
-            user3 = session.query(User).filter(User.user_id == 3).first()
+            user1 = (
+                session.execute(select(User).where(User.user_id == 1)).scalars().first()
+            )
+            user3 = (
+                session.execute(select(User).where(User.user_id == 3)).scalars().first()
+            )
             assert user1.full_name == "User 1"  # Not updated.
             assert user3.full_name == "User 3"  # Inserted.
-            assert session.query(User).count() == 3
+            assert session.scalar(select(func.count()).select_from(User)) == 3
 
     def test_partial_column_update(self, temp_db):
         """
@@ -220,7 +229,9 @@ class TestUpsertModelInstances:
             session.commit()
 
             # Verify only full_name was updated.
-            user1 = session.query(User).filter(User.user_id == 1).first()
+            user1 = (
+                session.execute(select(User).where(User.user_id == 1)).scalars().first()
+            )
             assert user1.full_name == "Updated User 1"
             assert user1.birth_date == date(1990, 1, 1)  # Not updated.
 
@@ -258,7 +269,7 @@ class TestUpsertModelInstances:
             )
             session.commit()
 
-            count = session.query(HeartRate).count()
+            count = session.scalar(select(func.count()).select_from(HeartRate))
             assert count == 2
 
         # Try to insert duplicate (should be ignored).
@@ -274,12 +285,14 @@ class TestUpsertModelInstances:
 
             # Verify value was NOT updated.
             hr = (
-                session.query(HeartRate)
-                .filter(HeartRate.timestamp == timestamp1)
+                session.execute(
+                    select(HeartRate).where(HeartRate.timestamp == timestamp1)
+                )
+                .scalars()
                 .first()
             )
             assert hr.value == 70  # Original value.
-            assert session.query(HeartRate).count() == 2
+            assert session.scalar(select(func.count()).select_from(HeartRate)) == 2
 
     def test_empty_list(self, temp_db):
         """
@@ -339,9 +352,13 @@ class TestUpsertModelInstances:
             session.commit()
 
             # Verify all operations.
-            assert session.query(User).count() == 4
-            user1 = session.query(User).filter(User.user_id == 1).first()
-            user3 = session.query(User).filter(User.user_id == 3).first()
+            assert session.scalar(select(func.count()).select_from(User)) == 4
+            user1 = (
+                session.execute(select(User).where(User.user_id == 1)).scalars().first()
+            )
+            user3 = (
+                session.execute(select(User).where(User.user_id == 3)).scalars().first()
+            )
             assert user1.full_name == "Updated User 1"
             assert user3.full_name == "User 3"
 
@@ -363,7 +380,9 @@ class TestUpsertModelInstances:
             session.commit()
 
             # Get original create_ts.
-            user1 = session.query(User).filter(User.user_id == 1).first()
+            user1 = (
+                session.execute(select(User).where(User.user_id == 1)).scalars().first()
+            )
             original_create_ts = user1.create_ts
 
         # Update the record (create_ts should not change).
@@ -381,7 +400,9 @@ class TestUpsertModelInstances:
             session.commit()
 
             # Verify create_ts did not change.
-            user1 = session.query(User).filter(User.user_id == 1).first()
+            user1 = (
+                session.execute(select(User).where(User.user_id == 1)).scalars().first()
+            )
             assert user1.create_ts == original_create_ts
             assert user1.full_name == "Updated User 1"
 
@@ -406,7 +427,7 @@ class TestUpsertModelInstances:
             session.commit()
 
             assert len(result) == 1000
-            count = session.query(User).count()
+            count = session.scalar(select(func.count()).select_from(User))
             assert count == 1000
 
     def test_null_values_in_optional_columns(self, temp_db):
@@ -427,7 +448,9 @@ class TestUpsertModelInstances:
             session.commit()
 
             # Verify NULL values were inserted.
-            user1 = session.query(User).filter(User.user_id == 1).first()
+            user1 = (
+                session.execute(select(User).where(User.user_id == 1)).scalars().first()
+            )
             assert user1.full_name is None
             assert user1.birth_date is None
 
@@ -488,7 +511,9 @@ class TestUpsertModelInstances:
 
             # Get original update_ts.
             activity1 = (
-                session.query(Activity).filter(Activity.activity_id == 1).first()
+                session.execute(select(Activity).where(Activity.activity_id == 1))
+                .scalars()
+                .first()
             )
             original_update_ts = activity1.update_ts
 
@@ -528,7 +553,9 @@ class TestUpsertModelInstances:
 
             # Verify update_ts was refreshed.
             activity1 = (
-                session.query(Activity).filter(Activity.activity_id == 1).first()
+                session.execute(select(Activity).where(Activity.activity_id == 1))
+                .scalars()
+                .first()
             )
             assert activity1.update_ts > original_update_ts
             assert activity1.favorite is True  # Verify the update worked.


### PR DESCRIPTION
## Summary

- Replace `declarative_base()` with `DeclarativeBase` class in models.py.
- Replace `sessionmaker(bind=engine)` with `Session(engine)` in db.py and conftest.py.
- Migrate all `session.query()` calls to `session.execute(select(...))` across db.py, processor.py, and test files.
- Replace `session.query(M).filter_by(...).delete()` with `session.execute(delete(M).where(...))` in processor.py.
- Replace `bulk_save_objects()` with core `insert()` for FIT metric bulk inserts (bypasses ORM identity map, avoids SQLite RETURNING sentinel mismatch with `DateTime(timezone=True)` composite PKs).
- Strength exercise/set inserts use `add_all()` (no composite DateTime PKs).
- All test assertions updated to match SA 2.0 patterns.

## Test plan

- [x] Full test suite passes (110 passed, 1 skipped).
- [x] Formatting checks pass (black, autoflake, docformatter).
- [ ] Manual smoke test with real Garmin data extraction.

Closes #29