### PR TITLE
fix: address Copilot review, bump to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.6.0] - 2026-04-17
+
+### Changed
+
+- **SQLAlchemy 2.0 ORM migration** ([#30](https://github.com/diegoscarabelli/garmin-health-data/pull/30)): Migrated all legacy SQLAlchemy 1.4 patterns to native 2.0 style, aligning runtime code with the `sqlalchemy>=2.0` dependency declared since v2.0.3.
+  - Model base: `declarative_base()` replaced with `DeclarativeBase` subclass.
+  - Sessions: `sessionmaker(bind=engine)` replaced with `Session(engine)` context manager.
+  - Queries: all `session.query()` calls replaced with `session.execute(select(...))`.
+  - Bulk deletes: `.filter_by(...).delete()` replaced with `session.execute(delete(...).where(...))`.
+  - FIT metric bulk inserts: `bulk_save_objects()` replaced with core `insert()` to bypass the ORM identity map and avoid SQLite's RETURNING sentinel mismatch with `DateTime(timezone=True)` composite PKs. Column keys are precomputed once per model to avoid repeated `__table__.columns` iteration on large FIT files.
+  - Strength exercise/set inserts: `bulk_save_objects()` replaced with `add_all()`.
+  - Test assertions for delete statements now verify the target table and WHERE clause rather than just checking that a DELETE was executed.
 
 ### Fixed
 
@@ -246,7 +257,8 @@ All data can be re-downloaded from Garmin Connect. This is the cleanest upgrade 
 - Flexible authentication with OAuth tokens.
 - Comprehensive documentation and examples.
 
-[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.6.0...HEAD
+[2.6.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.2.0...v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [2.6.0] - 2026-04-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ $ garmin extract
 | **FLOORS** | Floors climbed and descended | 15-min intervals |
 | **INTENSITY_MINUTES** | Moderate/vigorous activity minutes | 15-min intervals |
 | **ACTIVITIES_LIST** | Detailed activity summaries | Per activity |
+| **EXERCISE_SETS** | Per-set strength training data: reps, weight, ML-classified exercise name | Per activity |
 | **PERSONAL_RECORDS** | All-time bests across sports | As achieved |
 | **RACE_PREDICTIONS** | Predicted race times | Periodic updates |
 | **USER_PROFILE** | Demographics, fitness metrics | Periodic updates |
@@ -288,7 +289,7 @@ user (root table)
 ```
 *Foreign keys: `user_profile` → `user.user_id`*
 
-**Activities (9 tables)**
+**Activities (11 tables)**
 ```
 activity (main activity records)
 ├── activity_lap_metric (lap-by-lap metrics)
@@ -297,17 +298,12 @@ activity (main activity records)
 ├── activity_ts_metric (time-series sensor data)
 ├── cycling_agg_metrics (cycling-specific aggregates)
 ├── running_agg_metrics (running-specific aggregates)
+├── strength_exercise (per-exercise aggregates: sets, reps, volume, duration)
+├── strength_set (per-set data: reps, weight, ML-classified exercise name)
 ├── swimming_agg_metrics (swimming-specific aggregates)
 └── supplemental_activity_metric (additional activity metrics)
 ```
 *Foreign keys: `activity` → `user.user_id`; all child tables → `activity.activity_id`*
-
-**Strength Training (2 tables)**
-```
-strength_exercise (per-exercise aggregates: sets, reps, volume, duration)
-strength_set (per-set data: reps, weight, ML-classified exercise name)
-```
-*Foreign keys: both tables → `activity.activity_id`*
 
 **Sleep Metrics (7 tables)**
 ```

--- a/garmin_health_data/__version__.py
+++ b/garmin_health_data/__version__.py
@@ -2,4 +2,4 @@
 Version information for garmin-health-data.
 """
 
-__version__ = "2.5.0"
+__version__ = "2.6.0"

--- a/garmin_health_data/cli.py
+++ b/garmin_health_data/cli.py
@@ -326,7 +326,9 @@ def extract(
                     # Create FileSet for this timestamp
                     # Derive file_paths from matched files only to ensure the processor
                     # only receives files it can handle (those matching GARMIN_FILE_TYPES).
-                    matched_paths = [p for paths in files_by_type.values() for p in paths]
+                    matched_paths = [
+                        p for paths in files_by_type.values() for p in paths
+                    ]
                     file_set = FileSet(file_paths=matched_paths, files=files_by_type)
 
                     # Process this FileSet

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -1,8 +1,8 @@
 """
 Garmin Connect data extraction module for standalone use.
 
-Extracts activity files and JSON Garmin data from Garmin Connect API and saves them
-to the ingest directory. Designed for standalone applications without Apache Airflow
+Extracts activity files and JSON Garmin data from Garmin Connect API and saves them to
+the ingest directory. Designed for standalone applications without Apache Airflow
 dependencies.
 """
 
@@ -483,12 +483,11 @@ class GarminExtractor:
         """
         Extract activity files from Garmin Connect.
 
-        This method always processes dates inclusively — both start_date and
-        end_date are included in the extraction. The extract() function
-        handles any exclusion logic before passing dates to the Extractor
-        class. Downloads activity files with user ID, activity ID, and
-        activity start timestamp in filename. The file extension reflects the
-        actual format detected from the downloaded content.
+        This method always processes dates inclusively — both start_date and end_date
+        are included in the extraction. The extract() function handles any exclusion
+        logic before passing dates to the Extractor class. Downloads activity files with
+        user ID, activity ID, and activity start timestamp in filename. The file
+        extension reflects the actual format detected from the downloaded content.
 
         :return: List of saved activity file paths.
         """

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -2734,17 +2734,31 @@ class GarminProcessor(Processor):
         # synchronize_session=False, so stale instances may remain in the
         # map. Core insert also avoids the RETURNING sentinel mismatch
         # that SQLite triggers with DateTime(timezone=True) composite PKs.
+        #
+        # Column keys are precomputed once per model to avoid repeated
+        # __table__.columns iteration on large FIT files. Columns with
+        # server_default (create_ts) are excluded so the database applies
+        # the default rather than receiving a Python None.
+        ts_keys = [
+            c.key
+            for c in ActivityTsMetric.__table__.columns
+            if c.server_default is None
+        ]
+        split_keys = [
+            c.key
+            for c in ActivitySplitMetric.__table__.columns
+            if c.server_default is None
+        ]
+        lap_keys = [
+            c.key
+            for c in ActivityLapMetric.__table__.columns
+            if c.server_default is None
+        ]
+
         if ts_metrics:
             session.execute(
                 insert(ActivityTsMetric),
-                [
-                    {
-                        c.key: getattr(m, c.key)
-                        for c in ActivityTsMetric.__table__.columns
-                        if c.server_default is None
-                    }
-                    for m in ts_metrics
-                ],
+                [{k: getattr(m, k) for k in ts_keys} for m in ts_metrics],
             )
             click.echo(f"Processed {len(ts_metrics)} time-series records.")
         else:
@@ -2755,14 +2769,7 @@ class GarminProcessor(Processor):
         if split_metrics:
             session.execute(
                 insert(ActivitySplitMetric),
-                [
-                    {
-                        c.key: getattr(m, c.key)
-                        for c in ActivitySplitMetric.__table__.columns
-                        if c.server_default is None
-                    }
-                    for m in split_metrics
-                ],
+                [{k: getattr(m, k) for k in split_keys} for m in split_metrics],
             )
             click.echo(f"Processed {len(split_metrics)} split records.")
         else:
@@ -2771,14 +2778,7 @@ class GarminProcessor(Processor):
         if lap_metrics:
             session.execute(
                 insert(ActivityLapMetric),
-                [
-                    {
-                        c.key: getattr(m, c.key)
-                        for c in ActivityLapMetric.__table__.columns
-                        if c.server_default is None
-                    }
-                    for m in lap_metrics
-                ],
+                [{k: getattr(m, k) for k in lap_keys} for m in lap_metrics],
             )
             click.echo(f"Processed {len(lap_metrics)} lap records.")
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garmin-health-data"
-version = "2.5.0"
+version = "2.6.0"
 description = "Extract your Garmin Connect health data to a local SQLite database"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -21,10 +21,7 @@ from garmin_health_data.extractor import (
 # Bytes 8–11 are the ANT+ FIT protocol magic: b'.FIT'.
 _FIT_MAGIC = b"\x0e\x10\x00\x00\x00\x00\x00\x00.FIT\x00\x00"
 
-_TCX_CONTENT = (
-    b'<?xml version="1.0" encoding="UTF-8"?>'
-    b"<TrainingCenterDatabase/>"
-)
+_TCX_CONTENT = b'<?xml version="1.0" encoding="UTF-8"?>' b"<TrainingCenterDatabase/>"
 _GPX_CONTENT = b'<?xml version="1.0"?><gpx version="1.1"/>'
 _KML_CONTENT = b'<?xml version="1.0"?><kml/>'
 
@@ -677,8 +674,8 @@ class TestExtractActivityContent:
 @patch("garmin_health_data.extractor.time.sleep")
 class TestExtractFitActivitiesFormat:
     """
-    Integration tests verifying that extract_fit_activities saves files
-    with the correct extension based on detected content format.
+    Integration tests verifying that extract_fit_activities saves files with the correct
+    extension based on detected content format.
     """
 
     @pytest.fixture()

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import fitdecode
 import pytest
-from sqlalchemy import func, insert, select
+from sqlalchemy import delete, func, insert, select
 from sqlalchemy.orm import Session
 
 from garmin_health_data.models import (
@@ -1068,13 +1068,19 @@ class TestProcessStrengthMetrics:
         assert "totalReps" not in activity_data
         assert "otherField" in activity_data
 
-        # Verify delete was called via session.execute.
+        # Verify delete targets StrengthExercise for the correct activity_id.
+        expected_delete = delete(StrengthExercise).where(
+            StrengthExercise.activity_id == activity_id
+        )
         delete_calls = [
             call
             for call in mock_session.execute.call_args_list
             if hasattr(call.args[0], "is_delete") and call.args[0].is_delete
         ]
-        assert len(delete_calls) >= 1
+        assert len(delete_calls) == 1
+        stmt = delete_calls[0].args[0]
+        assert stmt.table.name == StrengthExercise.__tablename__
+        assert stmt.whereclause.compare(expected_delete.whereclause)
 
         # Assert - records were added.
         mock_session.add_all.assert_called_once()
@@ -1157,13 +1163,19 @@ class TestProcessStrengthMetrics:
         assert "activeSets" not in activity_data
         assert "totalReps" not in activity_data
 
-        # Verify delete was called via session.execute.
+        # Verify delete targets StrengthExercise for the correct activity_id.
+        expected_delete = delete(StrengthExercise).where(
+            StrengthExercise.activity_id == 12345
+        )
         delete_calls = [
             call
             for call in mock_session.execute.call_args_list
             if hasattr(call.args[0], "is_delete") and call.args[0].is_delete
         ]
-        assert len(delete_calls) >= 1
+        assert len(delete_calls) == 1
+        stmt = delete_calls[0].args[0]
+        assert stmt.table.name == StrengthExercise.__tablename__
+        assert stmt.whereclause.compare(expected_delete.whereclause)
 
         # Assert - no insert since sets are empty.
         mock_session.add_all.assert_not_called()
@@ -1246,13 +1258,19 @@ class TestProcessExerciseSets:
         # Act.
         processor._process_exercise_sets(file_path, mock_session)
 
-        # Verify delete was called via session.execute.
+        # Verify delete targets StrengthSet for the correct activity_id.
+        expected_delete = delete(StrengthSet).where(
+            StrengthSet.activity_id == 22320029355
+        )
         delete_calls = [
             call
             for call in mock_session.execute.call_args_list
             if hasattr(call.args[0], "is_delete") and call.args[0].is_delete
         ]
-        assert len(delete_calls) >= 1
+        assert len(delete_calls) == 1
+        stmt = delete_calls[0].args[0]
+        assert stmt.table.name == StrengthSet.__tablename__
+        assert stmt.whereclause.compare(expected_delete.whereclause)
 
         # Assert - records were added.
         mock_session.add_all.assert_called_once()
@@ -1350,13 +1368,17 @@ class TestProcessExerciseSets:
         # Act.
         processor._process_exercise_sets(file_path, mock_session)
 
-        # Verify delete was called via session.execute.
+        # Verify delete targets StrengthSet for the correct activity_id.
+        expected_delete = delete(StrengthSet).where(StrengthSet.activity_id == 12345)
         delete_calls = [
             call
             for call in mock_session.execute.call_args_list
             if hasattr(call.args[0], "is_delete") and call.args[0].is_delete
         ]
-        assert len(delete_calls) >= 1
+        assert len(delete_calls) == 1
+        stmt = delete_calls[0].args[0]
+        assert stmt.table.name == StrengthSet.__tablename__
+        assert stmt.whereclause.compare(expected_delete.whereclause)
         mock_session.add_all.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

Addresses Copilot review feedback from PR #30 and prepares the 2.6.0 release.

- **Tighter delete assertions**: Test delete assertions now verify the target table name and WHERE clause (via `.compare()`) instead of just checking that any DELETE was executed. Prevents false positives if deletes are added/changed.
- **Deduplicated core insert**: FIT metric bulk insert precomputes column keys once per model (excluding `server_default` columns like `create_ts`) instead of recomputing `__table__.columns` per row.
- **Version bump to 2.6.0**: Changelog updated with SA 2.0 migration (#30) and activity file format detection fix (#27).
- **Formatting**: Black/docformatter applied to files touched by prior PRs.

Closes #29.

## Test plan

- [x] All 127 tests pass (1 skipped).
- [x] `make check-format` clean.
- [x] Real extraction verified against Garmin Connect for Apr 10-17 (2 accounts, 157 files, 102.5 MB DB).