### PR TITLE
fix: chunk upsert_model_instances to respect SQLite parameter limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **SQLite parameter limit safety** : `upsert_model_instances` now automatically splits large batches into chunks so the total parameter count stays within SQLite's `SQLITE_MAX_VARIABLE_NUMBER` limit (999 on pre-3.32.0 builds). Previously, a single INSERT with many rows on wide tables (e.g., Sleep at 73 columns) could exceed the limit and fail. The conservative floor of 999 guarantees safety across all supported platforms.
+- **SQLite parameter limit safety**: `upsert_model_instances` now automatically splits large batches into chunks so the total parameter count stays within SQLite's `SQLITE_MAX_VARIABLE_NUMBER` limit (999 on pre-3.32.0 builds). Previously, a single INSERT with many rows on wide tables (e.g., Sleep at 73 columns) could exceed the limit and fail. The conservative floor of 999 guarantees safety across all supported platforms.
 
 ## [2.6.0] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.1] - 2026-04-17
+
+### Fixed
+
+- **SQLite parameter limit safety** : `upsert_model_instances` now automatically splits large batches into chunks so the total parameter count stays within SQLite's `SQLITE_MAX_VARIABLE_NUMBER` limit (999 on pre-3.32.0 builds). Previously, a single INSERT with many rows on wide tables (e.g., Sleep at 73 columns) could exceed the limit and fail. The conservative floor of 999 guarantees safety across all supported platforms.
+
 ## [2.6.0] - 2026-04-17
 
 ### Changed
@@ -259,7 +265,8 @@ All data can be re-downloaded from Garmin Connect. This is the cleanest upgrade 
 - Flexible authentication with OAuth tokens.
 - Comprehensive documentation and examples.
 
-[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.6.1...HEAD
+[2.6.1]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.3.0...v2.4.0

--- a/garmin_health_data/__version__.py
+++ b/garmin_health_data/__version__.py
@@ -2,4 +2,4 @@
 Version information for garmin-health-data.
 """
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"

--- a/garmin_health_data/processor_helpers.py
+++ b/garmin_health_data/processor_helpers.py
@@ -10,6 +10,11 @@ from sqlalchemy import func
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
+# Lowest SQLITE_MAX_VARIABLE_NUMBER across supported builds.
+# Pre-3.32.0 defaulted to 999; 3.32.0+ raised it to 32 766.
+# Using the floor guarantees safety on all platforms.
+_SQLITE_MAX_PARAMS = 999
+
 
 @dataclass
 class FileSet:
@@ -57,8 +62,10 @@ def upsert_model_instances(
     Bulk upsert SQLAlchemy ORM model instances into SQLite database tables.
 
     This function uses SQLite's INSERT ... ON CONFLICT syntax to perform
-    efficient bulk upsert operations in a single SQL statement, matching
-    the implementation pattern used in OpenETL for PostgreSQL.
+    efficient bulk upsert operations, matching the implementation pattern
+    used in OpenETL for PostgreSQL. Large batches are automatically split
+    into chunks so the total parameter count stays within SQLite's
+    SQLITE_MAX_VARIABLE_NUMBER limit.
 
     :param session: SQLAlchemy session.
     :param model_instances: List of model instances to upsert.
@@ -90,32 +97,38 @@ def upsert_model_instances(
         excluded_cols = set(conflict_columns) | {"create_ts", "update_ts"}
         update_columns = [col for col in model_columns if col not in excluded_cols]
 
-    # Create bulk insert statement with all values.
-    insert_stmt = sqlite_insert(model_class).values(values)
+    # Clamp chunk size so total parameters stay within the SQLite
+    # limit. Use the full model column count because SQLAlchemy
+    # fills in columns with Python-side defaults even when omitted
+    # from the values dicts.
+    num_cols = len(model_class.__table__.columns)
+    max_rows = max(1, _SQLITE_MAX_PARAMS // num_cols)
 
-    if on_conflict_update:
-        # Build update dictionary for ON CONFLICT DO UPDATE.
-        update_dict = {col: insert_stmt.excluded[col] for col in update_columns}
+    for chunk_start in range(0, len(values), max_rows):
+        chunk = values[chunk_start : chunk_start + max_rows]
 
-        # Automatically update update_ts column if it exists in the model.
-        # SQLite's DEFAULT CURRENT_TIMESTAMP only applies on INSERT, not UPDATE.
-        # We must explicitly set update_ts to the current timestamp on updates.
-        if hasattr(model_class, "update_ts"):
-            update_dict["update_ts"] = func.current_timestamp()
+        insert_stmt = sqlite_insert(model_class).values(chunk)
 
-        upsert_stmt = insert_stmt.on_conflict_do_update(
-            index_elements=conflict_columns, set_=update_dict
-        )
-    else:
-        # Ignore conflicts (insert-only).
-        upsert_stmt = insert_stmt.on_conflict_do_nothing(
-            index_elements=conflict_columns
-        )
+        if on_conflict_update:
+            # Build update dictionary for ON CONFLICT DO UPDATE.
+            update_dict = {col: insert_stmt.excluded[col] for col in update_columns}
 
-    # Execute the bulk upsert statement (single SQL statement for all rows).
-    session.execute(upsert_stmt)
+            # Automatically update update_ts column if it exists in the
+            # model. SQLite's DEFAULT CURRENT_TIMESTAMP only applies on
+            # INSERT, not UPDATE. We must explicitly set update_ts to the
+            # current timestamp on updates.
+            if hasattr(model_class, "update_ts"):
+                update_dict["update_ts"] = func.current_timestamp()
 
-    # Flush session to force immediate resolution of foreign key relationships.
-    session.flush()
+            upsert_stmt = insert_stmt.on_conflict_do_update(
+                index_elements=conflict_columns, set_=update_dict
+            )
+        else:
+            # Ignore conflicts (insert-only).
+            upsert_stmt = insert_stmt.on_conflict_do_nothing(
+                index_elements=conflict_columns
+            )
+
+        session.execute(upsert_stmt)
 
     return model_instances

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garmin-health-data"
-version = "2.6.0"
+version = "2.6.1"
 description = "Extract your Garmin Connect health data to a local SQLite database"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_processor_helpers.py
+++ b/tests/test_processor_helpers.py
@@ -478,7 +478,6 @@ class TestUpsertModelInstances:
 
         # Insert 500 heart rate records (forces multiple chunks).
         with Session(engine) as session:
-            base_ts = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
             records = [
                 HeartRate(
                     user_id=1,

--- a/tests/test_processor_helpers.py
+++ b/tests/test_processor_helpers.py
@@ -454,6 +454,126 @@ class TestUpsertModelInstances:
             assert user1.full_name is None
             assert user1.birth_date is None
 
+    def test_chunking_exceeds_parameter_limit(self, temp_db):
+        """
+        Test that large batches are split into chunks to stay within SQLite's
+        SQLITE_MAX_VARIABLE_NUMBER limit.
+
+        HeartRate has 4 columns (user_id, timestamp, value, create_ts). With
+        _SQLITE_MAX_PARAMS=999 the chunk size is 249 rows, so 500 records forces at
+        least two chunks.
+        """
+        engine = get_engine(temp_db)
+
+        # Create user first (foreign key requirement).
+        with Session(engine) as session:
+            user = User(user_id=1, full_name="User 1", birth_date=date(1990, 1, 1))
+            upsert_model_instances(
+                session=session,
+                model_instances=[user],
+                conflict_columns=["user_id"],
+                on_conflict_update=True,
+            )
+            session.commit()
+
+        # Insert 500 heart rate records (forces multiple chunks).
+        with Session(engine) as session:
+            base_ts = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+            records = [
+                HeartRate(
+                    user_id=1,
+                    timestamp=datetime(
+                        2024, 1, 1, i // 60, i % 60, 0, tzinfo=timezone.utc
+                    ),
+                    value=60 + (i % 40),
+                )
+                for i in range(500)
+            ]
+            result = upsert_model_instances(
+                session=session,
+                model_instances=records,
+                conflict_columns=["user_id", "timestamp"],
+                on_conflict_update=False,
+            )
+            session.commit()
+
+            assert len(result) == 500
+            count = session.scalar(select(func.count()).select_from(HeartRate))
+            assert count == 500
+
+    def test_chunking_with_conflict_update(self, temp_db):
+        """
+        Test that chunked upserts correctly update rows across chunk boundaries.
+        """
+        engine = get_engine(temp_db)
+
+        # Create user first (foreign key requirement).
+        with Session(engine) as session:
+            user = User(user_id=1, full_name="User 1", birth_date=date(1990, 1, 1))
+            upsert_model_instances(
+                session=session,
+                model_instances=[user],
+                conflict_columns=["user_id"],
+                on_conflict_update=True,
+            )
+            session.commit()
+
+        # Insert 500 heart rate records.
+        with Session(engine) as session:
+            records = [
+                HeartRate(
+                    user_id=1,
+                    timestamp=datetime(
+                        2024, 1, 1, i // 60, i % 60, 0, tzinfo=timezone.utc
+                    ),
+                    value=60,
+                )
+                for i in range(500)
+            ]
+            upsert_model_instances(
+                session=session,
+                model_instances=records,
+                conflict_columns=["user_id", "timestamp"],
+                on_conflict_update=True,
+            )
+            session.commit()
+
+        # Re-upsert with updated values (should update, not duplicate).
+        with Session(engine) as session:
+            updated_records = [
+                HeartRate(
+                    user_id=1,
+                    timestamp=datetime(
+                        2024, 1, 1, i // 60, i % 60, 0, tzinfo=timezone.utc
+                    ),
+                    value=99,
+                )
+                for i in range(500)
+            ]
+            upsert_model_instances(
+                session=session,
+                model_instances=updated_records,
+                conflict_columns=["user_id", "timestamp"],
+                on_conflict_update=True,
+            )
+            session.commit()
+
+            count = session.scalar(select(func.count()).select_from(HeartRate))
+            assert count == 500
+
+            # Verify a record from the second chunk was updated.
+            hr = (
+                session.execute(
+                    select(HeartRate).where(
+                        HeartRate.timestamp
+                        == datetime(2024, 1, 1, 4, 30, 0, tzinfo=timezone.utc)
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            assert hr.value == 99
+
     def test_update_ts_refreshes_on_conflict_update(self, temp_db):
         """
         Test that update_ts is refreshed when records are updated.


### PR DESCRIPTION
## Summary

- `upsert_model_instances` now automatically splits large batches into chunks so the total parameter count stays within SQLite's `SQLITE_MAX_VARIABLE_NUMBER` limit.
- Uses a conservative floor of 999 parameters (the default on pre-3.32.0 SQLite builds) to guarantee safety across all supported platforms (Linux, macOS, Windows).
- Wide models like Sleep (73 columns) previously risked exceeding the limit at ~14 rows per INSERT; chunking now caps at `max(1, 999 // num_cols)` rows per statement.
- Removed the unnecessary `session.flush()` after `session.execute()` since Core constructs already send SQL within the current transaction.
- Version bumped to 2.6.1.

## Test plan

- [x] Two new integration tests (`test_chunking_exceeds_parameter_limit`, `test_chunking_with_conflict_update`) verify multi-chunk inserts and updates across chunk boundaries.
- [x] All 14 processor_helpers tests pass.
- [x] Full test suite: 129 passed, 1 skipped, 0 failures.
- [x] Live extraction: `garmin extract --start-date 2026-04-13 --end-date 2026-04-17` completed successfully (94 files, 101,864 time-series records, 2 accounts).