### PR TITLE
feat(cli): add --keep-files flag to retain extracted files on disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,16 @@ garmin extract --db-path ~/my-garmin-data.db
 # Extract only specific accounts (multi-account setup)
 garmin extract --accounts 12345678
 garmin extract --accounts 12345678,87654321
+
+# Keep all extracted files (JSON, FIT, GPX, etc.) on disk after processing
+garmin extract --keep-files
 ```
+
+#### Keeping Extracted Files
+
+By default, extracted files are written to a temporary directory and deleted after they are loaded into the database. Pass `--keep-files` to retain them in a `garmin_files/` directory next to the database file (e.g. `./garmin_files/` for the default `./garmin_data.db`).
+
+This is useful as an offline backup of original Garmin payloads (raw JSON for daily metrics and FIT/TCX/GPX/KML files for activities), which can be re-imported into other tools. Files with the same name from a previous run are overwritten on subsequent runs; the directory itself is preserved across runs.
 
 #### Date Range Behavior
 

--- a/garmin_health_data/cli.py
+++ b/garmin_health_data/cli.py
@@ -111,12 +111,21 @@ def auth(email: Optional[str], password: Optional[str]):
     "Examples: --accounts 123,456 or --accounts 123 --accounts 456. "
     "Extracts all discovered accounts if not specified.",
 )
+@click.option(
+    "--keep-files",
+    is_flag=True,
+    default=False,
+    help="Keep all extracted files (JSON, FIT, GPX, etc.) on disk after "
+    "processing. Files are saved to 'garmin_files/' next to the database "
+    "file. Files with the same name are overwritten on subsequent runs.",
+)
 def extract(
     start_date: Optional[datetime],
     end_date: Optional[datetime],
     data_types: tuple,
     db_path: str,
     accounts: tuple,
+    keep_files: bool,
 ):
     """
     Extract Garmin Connect data and save to SQLite database.
@@ -190,9 +199,15 @@ def extract(
     )
     click.echo()
 
-    # Create temporary directory for extraction.
-    temp_dir = Path(tempfile.gettempdir()) / "garmin_extraction"
-    temp_dir.mkdir(exist_ok=True, parents=True)
+    # Determine extraction directory. When --keep-files is set, save files
+    # alongside the database for permanent retention; otherwise use a temp
+    # directory that gets cleaned up after processing.
+    if keep_files:
+        ingest_dir = Path(db_path).expanduser().resolve().parent / "garmin_files"
+        click.echo(f"💾 Keeping extracted files at: {ingest_dir}")
+    else:
+        ingest_dir = Path(tempfile.gettempdir()) / "garmin_extraction"
+    ingest_dir.mkdir(exist_ok=True, parents=True)
 
     try:
         # Step 1: Extract data from Garmin Connect.
@@ -206,7 +221,7 @@ def extract(
         click.echo()
 
         result = extract_data(
-            ingest_dir=temp_dir,
+            ingest_dir=ingest_dir,
             data_interval_start=format_date(start_date.date()),
             data_interval_end=format_date(end_date.date()),
             data_types=data_types_list,
@@ -243,8 +258,8 @@ def extract(
         )
         click.echo()
 
-        # Get all files from temp directory.
-        all_files = list(temp_dir.glob("**/*"))
+        # Get all files from extraction directory.
+        all_files = list(ingest_dir.glob("**/*"))
         file_paths = [f for f in all_files if f.is_file()]
 
         if file_paths:
@@ -375,9 +390,9 @@ def extract(
         click.echo("   • Run 'garmin extract' again later to update with new data")
 
     finally:
-        # Clean up temporary directory.
-        if temp_dir.exists():
-            shutil.rmtree(temp_dir)
+        # Clean up temporary directory unless --keep-files was set.
+        if not keep_files and ingest_dir.exists():
+            shutil.rmtree(ingest_dir)
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,11 +2,15 @@
 Tests for CLI commands.
 """
 
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 from click.testing import CliRunner
 from sqlalchemy.exc import ArgumentError
 
-from garmin_health_data.cli import verify
+from garmin_health_data.cli import extract, verify
 from garmin_health_data.db import create_tables, get_session
 
 
@@ -55,3 +59,123 @@ def test_verify_nonexistent_db(tmp_path):
 
     assert result.exit_code != 0
     assert "does not exist" in result.output
+
+
+def _stub_extract_no_files(*args, **kwargs):
+    """
+    Stub for extract_data that returns no files so the CLI exits early after the cleanup
+    branch runs.
+    """
+    return {"garmin_files": 0, "activity_files": 0}
+
+
+def test_extract_default_uses_temp_dir_and_cleans_up(tmp_path):
+    """
+    Without --keep-files, the CLI uses the system temp directory for extraction and
+    removes it after processing.
+    """
+    db_path = tmp_path / "test.db"
+    create_tables(str(db_path))
+
+    expected_temp = Path(tempfile.gettempdir()) / "garmin_extraction"
+
+    runner = CliRunner()
+    with (
+        patch("garmin_health_data.cli.ensure_authenticated"),
+        patch(
+            "garmin_health_data.cli.extract_data",
+            side_effect=_stub_extract_no_files,
+        ) as mock_extract,
+    ):
+        result = runner.invoke(
+            extract,
+            [
+                "--db-path",
+                str(db_path),
+                "--start-date",
+                "2025-01-01",
+                "--end-date",
+                "2025-01-02",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_extract.call_args.kwargs["ingest_dir"] == expected_temp
+    assert not expected_temp.exists()
+
+
+def test_extract_keep_files_writes_next_to_db_and_persists(tmp_path):
+    """
+    With --keep-files, the CLI uses a 'garmin_files/' directory beside the database file
+    and does not remove it after processing.
+    """
+    db_path = tmp_path / "test.db"
+    create_tables(str(db_path))
+
+    expected_dir = tmp_path / "garmin_files"
+
+    runner = CliRunner()
+    with (
+        patch("garmin_health_data.cli.ensure_authenticated"),
+        patch(
+            "garmin_health_data.cli.extract_data",
+            side_effect=_stub_extract_no_files,
+        ) as mock_extract,
+    ):
+        result = runner.invoke(
+            extract,
+            [
+                "--db-path",
+                str(db_path),
+                "--start-date",
+                "2025-01-01",
+                "--end-date",
+                "2025-01-02",
+                "--keep-files",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_extract.call_args.kwargs["ingest_dir"] == expected_dir
+    assert expected_dir.exists()
+    assert expected_dir.is_dir()
+    assert "Keeping extracted files at" in result.output
+
+
+def test_extract_keep_files_preserves_existing_files(tmp_path):
+    """
+    With --keep-files, files already present in the target directory are preserved
+    across runs (the directory itself is not wiped).
+    """
+    db_path = tmp_path / "test.db"
+    create_tables(str(db_path))
+
+    files_dir = tmp_path / "garmin_files"
+    files_dir.mkdir()
+    sentinel = files_dir / "previous_run.json"
+    sentinel.write_text('{"existing": true}')
+
+    runner = CliRunner()
+    with (
+        patch("garmin_health_data.cli.ensure_authenticated"),
+        patch(
+            "garmin_health_data.cli.extract_data",
+            side_effect=_stub_extract_no_files,
+        ),
+    ):
+        result = runner.invoke(
+            extract,
+            [
+                "--db-path",
+                str(db_path),
+                "--start-date",
+                "2025-01-01",
+                "--end-date",
+                "2025-01-02",
+                "--keep-files",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert sentinel.exists()
+    assert sentinel.read_text() == '{"existing": true}'


### PR DESCRIPTION
## Summary

Adds a `--keep-files` flag to `garmin extract` that preserves all extracted files (JSON daily metrics, FIT/TCX/GPX/KML activity files) in a `garmin_files/` directory next to the SQLite database, instead of writing them to a temporary directory that is deleted after processing.

This gives users an offline backup of original Garmin payloads, which can be re-imported into other tools (avoiding lock-in to a single database/tool).

## Changes

- New `--keep-files` Click option on `garmin extract` (default off, current behavior unchanged).
- When enabled, extraction writes to `<dirname(db_path)>/garmin_files/` and the cleanup `rmtree` is skipped.
- Files with the same name from a previous run are overwritten on subsequent runs; the directory itself is preserved across runs.
- README updated with usage and a "Keeping Extracted Files" subsection.
- Three new CLI tests covering: default cleanup behavior, persistence with the flag, and that pre-existing files in the directory are preserved.

## Test plan

- [x] `pytest` passes (132 passed, 1 skipped).
- [x] `--keep-files` writes to `<db dir>/garmin_files/` and skips cleanup.
- [x] Default behavior unchanged: temp dir is created and removed.
- [x] Pre-existing files in target dir are preserved across runs.
- [ ] Manual smoke test with a real Garmin account (deferred).

Closes #35.