### PR TITLE
fix(version-check): clamp negative ages, ship v2.7.1 to unblock Windows CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,7 +298,9 @@ All data can be re-downloaded from Garmin Connect. This is the cleanest upgrade 
 - Flexible authentication with OAuth tokens.
 - Comprehensive documentation and examples.
 
-[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.6.1...HEAD
+[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.1...HEAD
+[2.7.1]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.0...v2.7.1
+[2.7.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.6.1...v2.7.0
 [2.6.1]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.4.0...v2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] - 2026-04-28
+
+### Fixed
+
+- **Windows CI flake on `test_refreshes_stale_cache`**: `_read_cached()` computed `age = time.time() - st_mtime` and treated the cache as stale only when `age >= CACHE_TTL_SECONDS`. On Windows the NTFS mtime resolution is finer than `time.time()`, so a file written immediately before the check could have an mtime slightly *after* the current clock; the resulting negative age made a `TTL=0` test (and any TTL+race) treat the cache as fresh. Negative ages are now clamped to `0.0`, restoring the intended "stale at TTL=0" behavior.
+
 ## [2.7.0] - 2026-04-27
 
 ### Added

--- a/garmin_health_data/__version__.py
+++ b/garmin_health_data/__version__.py
@@ -2,4 +2,4 @@
 Version information for garmin-health-data.
 """
 
-__version__ = "2.7.0"
+__version__ = "2.7.1"

--- a/garmin_health_data/version_check.py
+++ b/garmin_health_data/version_check.py
@@ -84,7 +84,11 @@ def _read_cached() -> Optional[str]:
     if not CACHE_PATH.exists():
         return None
     try:
-        age = time.time() - CACHE_PATH.stat().st_mtime
+        # Clamp negative ages to 0: on Windows, NTFS mtime resolution is
+        # finer than time.time(), so age can be slightly negative right after
+        # a write. Without the clamp a TTL of 0 would (wrongly) treat the
+        # cache as fresh.
+        age = max(0.0, time.time() - CACHE_PATH.stat().st_mtime)
     except OSError:
         return None
     if age >= CACHE_TTL_SECONDS:

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -3,6 +3,8 @@ Tests for the optional PyPI version-check helper.
 """
 
 import json
+import os
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -161,6 +163,32 @@ def test_refreshes_stale_cache(isolated_cache, capsys, monkeypatch):
     assert "999.0.0" in out
     # Cache was rewritten with the fresh value.
     assert json.loads(isolated_cache.read_text())["latest"] == "999.0.0"
+
+
+def test_refreshes_when_mtime_is_in_the_future(isolated_cache, capsys, monkeypatch):
+    """
+    On Windows, NTFS mtime resolution is finer than ``time.time()`` so a file written
+    immediately before the check can have an mtime slightly *after* the current clock.
+
+    The cache must still be considered stale at TTL=0 rather than returning the cached
+    value because age is negative.
+    """
+
+    isolated_cache.write_text(json.dumps({"latest": "0.0.1"}))
+    # Force the cache file's mtime 1 second into the future to deterministically
+    # simulate the Windows clock-resolution race.
+    future = time.time() + 1.0
+    os.utime(isolated_cache, (future, future))
+    monkeypatch.setattr(version_check, "CACHE_TTL_SECONDS", 0)
+
+    with patch.object(
+        version_check.requests,
+        "get",
+        return_value=_mock_pypi_response("999.0.0"),
+    ):
+        version_check.check_for_newer_version()
+
+    assert "999.0.0" in capsys.readouterr().out
 
 
 def test_silent_on_malformed_cache(isolated_cache, capsys):


### PR DESCRIPTION
## Summary

The Windows CI job has been failing on every push to main since v2.7.0 because `test_refreshes_stale_cache` (intentionally) sets `CACHE_TTL_SECONDS = 0` and writes a cache file immediately before the check.

On Windows, NTFS mtime resolution is finer than `time.time()`, so the file's mtime can land slightly *after* the current clock. That makes `age = time.time() - st_mtime` negative, and `-0.001 >= 0` evaluates False, so `_read_cached()` (wrongly) returns the cached `"0.0.1"` instead of treating it as stale. The fetched `"999.0.0"` upgrade hint never prints, and the assertion fails.

This PR clamps the age to `max(0.0, time.time() - st_mtime)` so a future-dated mtime is treated as age 0. Adds a deterministic regression test (`test_refreshes_when_mtime_is_in_the_future`) that reproduces the race on every platform via `os.utime`. Bumps to **v2.7.1** so the patched build flows out via PyPI.

## Test plan

- [x] `test_refreshes_when_mtime_is_in_the_future` fails without the fix and passes with it (verified locally with `git stash` + re-run)
- [x] Full local test suite: `181 passed, 1 skipped`
- [ ] Confirm CI passes on `windows-latest, 3.10/3.11/3.12`
- [ ] Tag `v2.7.1` after merge to trigger PyPI publish workflow