### PR TITLE
docs(readme): restructure for clarity, separate Usage from Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,11 @@ Extract your complete Garmin Connect health and activity data to a local SQLite 
 
 ## Features
 
-- ⚡ **Zero Configuration**: Single command to get started.
-- 🖥️ **Cross-Platform**: Works on macOS, Linux, Windows.
-- 💾 **Local Storage**: SQLite database - your data stays on your machine.
-- 🏥 **Comprehensive Health Data**: Sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics.
-- 🏃 **Activity Data**: FIT files with detailed time-series metrics, lap data, split data.
-- 👥 **Multi-Account**: Extract data from multiple Garmin Connect accounts (e.g., family members) into a single database. Run `garmin auth` once per account — accounts are discovered and extracted automatically.
-- 🔄 **Auto-Resume & Crash Recovery**: Automatically detects the last update and syncs new data; files left mid-process from a crashed run are auto-recovered on the next invocation.
-- 📁 **File Lifecycle**: Every extracted file is preserved on disk in a four-folder pipeline (`ingest/process/storage/quarantine`) for offline backup and post-mortem inspection.
-- 🛡️ **Failure Isolation**: Per-date, per-data-type, per-activity, and per-FileSet error handling — a single transient failure is logged and skipped while the rest of the run continues.
+- 🏥 **Comprehensive data**: sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics — plus FIT activity files with detailed time-series, laps, and splits — into a single local SQLite database.
+- 👥 **Multi-account**: one database across multiple Garmin Connect accounts (e.g. family members). Run `garmin auth` once per account; extraction discovers and processes them automatically.
+- 🛡️ **Resilient pipeline**: four-folder lifecycle (`ingest/process/storage/quarantine`), auto-resume from the last update, crash recovery, and per-date / per-data-type / per-activity / per-FileSet failure isolation. Original files are preserved on disk for offline backup and post-mortem inspection.
+- 🔐 **Self-contained Garmin client**: bundled SSO/MFA login client, no third-party dependency for API access.
+- 🖥️ **Cross-platform**: macOS, Linux, Windows. Python 3.10+.
 
 ## Requirements
 
@@ -56,7 +52,7 @@ That's it! Your data is now in a local SQLite database (`garmin_data.db`).
 
 ## Usage
 
-### Authentication
+### Authentication & multi-account
 
 ```bash
 # Interactive authentication (one-time setup, run once per account)
@@ -65,40 +61,16 @@ garmin auth
 # If you have MFA enabled, you'll be prompted for your code
 ```
 
-- `garmin auth` always performs a fresh login and refreshes your OAuth tokens, even if valid tokens already exist.
-- After login, your Garmin user ID is auto-detected and tokens are stored in `~/.garminconnect/<user_id>/`.
-- Access tokens (~18h) are auto-refreshed transparently using the refresh token (30 days, rotates on each use). As long as you extract at least once within 30 days, tokens stay valid indefinitely.
-- You typically only need to run `garmin auth` once per account initially, or after 30+ days of inactivity.
-- `garmin extract` automatically checks for existing tokens and only prompts for authentication if they're missing.
-- **Recommendation:** Run `garmin auth` once per account for initial setup, then just use `garmin extract` for regular data extraction.
+`garmin auth` performs a fresh login and stores OAuth tokens locally. Tokens auto-refresh transparently as long as you extract at least once every 30 days, so you typically only run `garmin auth` once per account or after a long pause. `garmin extract` checks for existing tokens and only prompts for authentication if they're missing.
 
-#### How Authentication Works
-
-`garmin auth` uses a self-contained SSO client (`garmin_health_data/garmin_client/`) that tries five login strategies in order until one succeeds:
-
-1. Portal web login via `curl_cffi` (TLS browser fingerprint impersonation, 30-45s pre-submit delay)
-2. Portal web login via `requests` (30-45s pre-submit delay)
-3. Mobile portal login via `curl_cffi` (mobile TLS impersonation, 30-45s pre-submit delay)
-4. Mobile login via `requests` (30-45s pre-submit delay)
-5. Widget login via `curl_cffi` (last resort — 429s reliably under current Cloudflare config, kept for future use)
-
-**If you see a 30-45 second pause during `garmin auth`, this is normal.** The delay is a deliberate Cloudflare WAF countermeasure — submitting credentials too quickly triggers a 429 rate limit. Tokens obtained are DI OAuth2 Bearer tokens; no session cookies or password are stored after the initial login.
-
-If all five strategies are exhausted without success (uncommon — typically only during Garmin-side outages), `garmin auth` will exit with an error. Wait a few minutes and retry.
-
-#### Multi-Account Support
-
-You can extract data from multiple Garmin Connect accounts (e.g., family members) into the same database. Run `garmin auth` once for each account:
+For multiple accounts (e.g. family members), authenticate each in turn — they all extract into the same database:
 
 ```bash
-# Authenticate first account
 garmin auth --email user1@example.com --password pass1
-
-# Authenticate second account
 garmin auth --email user2@example.com --password pass2
 ```
 
-Tokens are stored in per-account subdirectories:
+Tokens are stored in per-account subdirectories and discovered automatically:
 
 ```text
 ~/.garminconnect/
@@ -108,11 +80,94 @@ Tokens are stored in per-account subdirectories:
     └── garmin_tokens.json
 ```
 
-Accounts are discovered automatically by scanning for numeric subdirectories. All discovered accounts are extracted sequentially when running `garmin extract`, with per-account error isolation (one failing account doesn't block others).
+All discovered accounts are extracted sequentially when running `garmin extract`, with per-account error isolation (one failing account doesn't block others).
 
-### Data Extraction
+> Login strategies, token rotation, and the 30-45s anti-rate-limit pause: see [Authentication internals](#reference).
 
-#### Extract command flags
+### Extracting data
+
+```bash
+# Auto-detect range (resumes from last update, or last 30 days if empty)
+garmin extract
+
+# Specific date range
+garmin extract --start-date 2024-01-01 --end-date 2024-12-31
+
+# Specific data types
+garmin extract --data-types SLEEP --data-types HEART_RATE --data-types ACTIVITY
+
+# Specific accounts (comma- or repeat-style)
+garmin extract --accounts 12345678,87654321
+
+# Custom database location
+garmin extract --db-path ~/my-garmin-data.db
+
+# Backup-only: download files, do not load into the DB
+garmin extract --extract-only
+
+# Process files already in ingest/, skip the API
+garmin extract --process-only
+```
+
+> Full flag table, file lifecycle, retries, and date-handling rules: see [Reference](#reference).
+
+### Common workflows
+
+**Initial extraction** — first run, no flags, gets the last 30 days:
+
+```bash
+$ garmin extract
+📅 Using default start date: 2024-11-20 (30 days ago)
+📆 Date range: 2024-11-20 to 2024-12-20
+✅ Extracted 1,234 files
+```
+
+**Weekly resume** — same command, just new data since the last run:
+
+```bash
+$ garmin extract
+📅 Auto-detected start date: 2024-12-21 (day after last update)
+📆 Date range: 2024-12-21 to 2024-12-27
+✅ Extracted 87 files  # Only new data!
+```
+
+**Catching up after a gap** — same command, fills the missing window automatically:
+
+```bash
+$ garmin extract
+📅 Auto-detected start date: 2024-12-28 (day after last update)
+📆 Date range: 2024-12-28 to 2025-01-10
+✅ Extracted 156 files  # Automatically fills the gap
+```
+
+### Inspecting your data
+
+```bash
+# Show row counts and last update dates per table
+garmin info
+
+Last Update Dates:
+   • Activity: 2024-12-18          # Haven't exercised in 2 days
+   • Body Battery: 2024-12-20       # Up to date
+   • Floors: 2024-12-20             # Up to date
+   • Heart Rate: 2024-12-20         # Up to date
+   • Sleep: 2024-12-20              # Up to date
+   • Steps: 2024-12-20              # Up to date
+   • Stress: 2024-12-20             # Up to date
+   ...
+
+# Check a specific database
+garmin info --db-path ~/my-garmin-data.db
+
+# Verify database integrity (table count + SQLite PRAGMA integrity_check)
+garmin verify
+```
+
+The data lives in a single SQLite file (default `./garmin_data.db`). Query it with `sqlite3`, [DuckDB](https://duckdb.org/), [pandas.read_sql](https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html), or any other SQLite-compatible tool. See [Data Catalog](#data-catalog) for the table layout.
+
+## Reference
+
+### `extract` command flags
 
 | Flag | Type | Purpose |
 | --- | --- | --- |
@@ -124,31 +179,8 @@ Accounts are discovered automatically by scanning for numeric subdirectories. Al
 | `--extract-only` | Flag | Download to `garmin_files/ingest/` and stop; do not load into the DB. |
 | `--process-only` | Flag | Skip the API; load whatever is currently in `garmin_files/ingest/`. Does not require authentication. Mutually exclusive with `--extract-only`. |
 
-```bash
-# Auto-detect date range (extracts from last update to today)
-garmin extract
-
-# Specify custom date range
-garmin extract --start-date 2024-01-01 --end-date 2024-12-31
-
-# Extract specific data types only
-garmin extract --data-types SLEEP --data-types HEART_RATE --data-types ACTIVITY
-
-# Use custom database location
-garmin extract --db-path ~/my-garmin-data.db
-
-# Extract only specific accounts (multi-account setup)
-garmin extract --accounts 12345678
-garmin extract --accounts 12345678,87654321
-
-# Extract files only, do not load into the database
-garmin extract --extract-only
-
-# Process files already in ingest/, do not call the Garmin API
-garmin extract --process-only
-```
-
-#### File Lifecycle
+<details>
+<summary><strong>File lifecycle</strong></summary>
 
 By default, every extracted file is preserved on disk in a four-folder lifecycle next to the SQLite database (e.g. `./garmin_files/` for the default `./garmin_data.db`):
 
@@ -165,7 +197,12 @@ This mirrors the openetl pipeline pattern. State transitions are filesystem move
 
 **Inspecting quarantine:** look in `garmin_files/quarantine/` to see which files failed processing, fix the underlying issue (parser bug, malformed payload, etc.), then move the files back to `garmin_files/ingest/` and run `garmin extract --process-only`.
 
-#### Failure Handling
+**Pipeline stages**: the full pipeline (extract → process) runs by default. `--extract-only` writes to `ingest/` and stops; `--process-only` skips the API and consumes whatever is in `ingest/`. The two flags are mutually exclusive. `--process-only` does not auto-detect dates (there are no dates to fetch).
+
+</details>
+
+<details>
+<summary><strong>Failure handling &amp; retries</strong></summary>
 
 A single transient failure does not abort the run. Failures are isolated and reported at four levels:
 
@@ -178,114 +215,73 @@ A single transient failure does not abort the run. Failures are isolated and rep
 
 **End-of-run summary**: every recorded failure is listed at the end of the run, grouped by data type, so you always know exactly what was skipped and can target a re-run with explicit `--start-date` / `--end-date`.
 
-#### Pipeline Stages
+</details>
 
-The full pipeline (extract → process) runs by default. Two flags split the stages:
+<details>
+<summary><strong>Date range behavior &amp; auto-detection</strong></summary>
 
-- `--extract-only`: download files into `ingest/` and stop. Useful for backup-only workflows or for manual inspection before loading.
-- `--process-only`: skip the API entirely; process whatever is currently in `ingest/`. Useful for retrying after a parsing fix, or for processing files that arrived from elsewhere. Does not require Garmin authentication.
-
-Note: `--process-only` does not trigger auto-detect of dates (there are no dates to fetch). It just consumes whatever is in `ingest/`. The two flags are mutually exclusive.
-
-#### Date Range Behavior
-
-The date range parameters `--start-date` and `--end-date` define the period for data extraction:
+`--start-date` and `--end-date` define the extraction window:
 
 - `--start-date`: **Inclusive**, data from this date is included.
-- `--end-date`: **Exclusive**, data from this date is NOT included (except when start and end dates are the same, then inclusive).
+- `--end-date`: **Exclusive**, data from this date is NOT included (except when start and end are the same day, then inclusive).
 - Example: `--start-date 2024-01-01 --end-date 2024-01-31` extracts Jan 1-30 (31st excluded).
 - Example: `--start-date 2024-01-15 --end-date 2024-01-15` extracts Jan 15 only (same-day inclusive).
 
-#### Automatic Date Detection
+**Auto-detection** runs whenever `--start-date` is omitted:
 
-One of the key features of garmin-health-data is that you can run `garmin extract` anytime without specifying dates, and it automatically continues from where it left off:
+1. **First run (empty database)**: extracts the last 30 days.
+2. **Subsequent runs (existing data)**: queries 10 core time-series tables (sleep, heart_rate, activity, stress, body_battery, steps, respiration, floors, intensity_minutes, training_readiness), takes the **maximum** date across them, and starts from the day after.
 
-1. **First Run (Empty Database)**
-   - Extracts the last 30 days of data.
-   - Creates your initial database.
+Using the maximum (rather than per-table latest) means each automatic run covers all data types up to the most recent extraction, even if some types have no rows for some days (e.g. no activities recorded, no training readiness calculated). This keeps the resume logic simple, predictable, and free of redundant API calls.
 
-2. **Subsequent Runs (Existing Data)**
-   - Queries 10 core time-series tables (sleep, heart_rate, activity, stress, body_battery, steps, respiration, floors, intensity_minutes, training_readiness).
-   - Finds the **most recent (maximum) date** across these tables.
-   - Automatically starts from the day after this maximum date.
-   - Extracts up to today.
+**Example:** if your database has sleep data through Dec 20 but activities only through Dec 18 (you didn't exercise on Dec 19-20), the next extraction starts from Dec 21. Sleep data for Dec 19-20 was already extracted, no activity data exists for those days, and the Dec 21 run picks up everything.
 
-This approach assumes that each automatic extraction covers all data types up to the maximum date, even if some specific data types have no data for certain days (e.g., no activities recorded, no training readiness calculated). Using the maximum date ensures:
-- Only new data is extracted (efficient, no redundant API calls).
-- Gaps in specific data types are automatically filled when available.
-- Simple, predictable behavior for users.
+</details>
 
-**Example:** 
+<details>
+<summary><strong>Authentication internals</strong></summary>
 
-If your database has sleep data through Dec 20th but activities only through Dec 18th (you didn't exercise on Dec 19-20), the next extraction starts from Dec 21st. This is correct because:
-- Sleep data for Dec 19-20 was already extracted.
-- No activity data exists for Dec 19-20 (you didn't exercise).
-- The Dec 21st extraction will get all available data for that day.
+`garmin auth` uses a self-contained SSO client (`garmin_health_data/garmin_client/`) that tries five login strategies in order until one succeeds:
 
-### Duplicate Prevention & Reprocessing
+1. Portal web login via `curl_cffi` (TLS browser fingerprint impersonation, 30-45s pre-submit delay).
+2. Portal web login via `requests` (30-45s pre-submit delay).
+3. Mobile portal login via `curl_cffi` (mobile TLS impersonation, 30-45s pre-submit delay).
+4. Mobile login via `requests` (30-45s pre-submit delay).
+5. Widget login via `curl_cffi` (last resort — 429s reliably under current Cloudflare config, kept for future use).
 
-This package prevents duplicates through a three-tier approach:
+**If you see a 30-45 second pause during `garmin auth`, this is normal.** The delay is a deliberate Cloudflare WAF countermeasure — submitting credentials too quickly triggers a 429 rate limit. Tokens obtained are DI OAuth2 Bearer tokens; no session cookies or password are stored after the initial login.
 
-1. **FIT Activity Metrics**: Uses delete+insert pattern for time-series, lap, and split metrics. Existing rows are deleted and fresh data re-inserted in the same transaction, handling added/removed laps or records between reprocesses. The `ts_data_available` flag tracks whether time-series data exists.
-2. **JSON Wellness Time-Series**: Uses `INSERT...ON CONFLICT DO NOTHING` for idempotent upserts. Reprocessing the same date won't create duplicates.
-3. **Main Records (activities, sleep)**: Uses `INSERT...ON CONFLICT DO UPDATE` to update existing records with new data.
+If all five strategies are exhausted without success (uncommon — typically only during Garmin-side outages), `garmin auth` exits with an error. Wait a few minutes and retry.
+
+**Token lifecycle:**
+
+- Access tokens (~18h) auto-refresh transparently using the refresh token (30 days, rotates on each use). As long as you extract at least once within 30 days, tokens stay valid indefinitely.
+- `garmin auth` always performs a fresh login and refreshes tokens, even if valid ones already exist.
+- `garmin extract` checks for existing tokens and only prompts for authentication if they're missing.
+- After login, your Garmin user ID is auto-detected and tokens are stored in `~/.garminconnect/<user_id>/`.
+
+</details>
+
+<details>
+<summary><strong>Duplicate prevention &amp; reprocessing</strong></summary>
+
+Duplicates are prevented through a three-tier approach:
+
+1. **FIT activity metrics** (time-series, laps, splits): delete+insert pattern. Existing rows are deleted and fresh data re-inserted in the same transaction, handling added/removed laps or records between reprocesses. The `ts_data_available` flag tracks whether time-series data exists.
+2. **JSON wellness time-series** (heart rate, sleep movement, stress, body battery, etc.): `INSERT...ON CONFLICT DO NOTHING` for idempotent upserts.
+3. **Main records** (activities, sleep, user profile): `INSERT...ON CONFLICT DO UPDATE` to refresh existing records with new data.
 
 This means you can safely:
-- **Reprocess dates** without creating duplicate time-series points
-- **Backfill missing data** by re-extracting date ranges
-- **Retry failed extractions** without manual cleanup
 
-**GarminDB comparison**: GarminDB uses SQLAlchemy `session.merge()` operations (via `insert_or_update()` methods) that handle duplicates at the ORM level. However, this behavior is not explicitly documented. `garmin-health-data` uses explicit SQL-level `ON CONFLICT` clauses that make idempotency guarantees clear and verifiable at the database level.
+- **Reprocess dates** without creating duplicate time-series points.
+- **Backfill missing data** by re-extracting date ranges.
+- **Retry failed extractions** without manual cleanup.
 
-#### Data Types
+</details>
 
-You can limit extraction to specific data types using the `--data-types` parameter. If omitted, all data types are extracted. The `--data-types` parameter accepts the exact values from the "Data Type" column in the [Data Types](#data-types) table below (e.g., `SLEEP`, `HEART_RATE`, `ACTIVITY`, `STRESS`, etc.).
+## Data Catalog
 
-### View Database Info
-
-```bash
-# Show statistics and last update dates
-garmin info
-
-Last Update Dates:
-   • Activity: 2024-12-18          # Haven't exercised in 2 days
-   • Body Battery: 2024-12-20       # Up to date
-   • Floors: 2024-12-20             # Up to date
-   • Heart Rate: 2024-12-20         # Up to date
-   • Sleep: 2024-12-20              # Up to date
-   • Steps: 2024-12-20              # Up to date
-   • Stress: 2024-12-20             # Up to date
-   ...
-
-# Check specific database
-garmin info --db-path ~/my-garmin-data.db
-```
-
-Next `garmin extract` will start from 2024-12-21 (the day after the maximum date, 2024-12-20), ensuring all data types are updated.
-
-### Example Workflow
-
-```bash
-# Week 1: Initial extraction
-$ garmin extract
-📅 Using default start date: 2024-11-20 (30 days ago)
-📆 Date range: 2024-11-20 to 2024-12-20
-✅ Extracted 1,234 files
-
-# Week 2: Automatic resume (just run the same command!)
-$ garmin extract
-📅 Auto-detected start date: 2024-12-21 (day after last update)
-📆 Date range: 2024-12-21 to 2024-12-27
-✅ Extracted 87 files  # Only new data!
-
-# Week 3: Missed a few days? No problem!
-$ garmin extract
-📅 Auto-detected start date: 2024-12-28 (day after last update)
-📆 Date range: 2024-12-28 to 2025-01-10
-✅ Extracted 156 files  # Automatically fills the gap
-```
-
-## Data Types
+### Data Types
 
 | Data Type | Description | Frequency |
 |-----------|-------------|-----------|
@@ -305,11 +301,9 @@ $ garmin extract
 | **USER_PROFILE** | Demographics, fitness metrics | Periodic updates |
 | **ACTIVITY** | Binary FIT files with detailed time-series sensor data | Per activity |
 
-## Database Schema
+### Database Schema
 
-The SQLite database contains 33 tables organized by category. The complete schema is defined in [garmin_health_data/tables.ddl](garmin_health_data/tables.ddl) following the same pattern as the [openetl project](https://github.com/diegoscarabelli/openetl). The schema includes inline documentation comments for all tables and columns, which are preserved in the SQLite database.
-
-**Viewing inline documentation:**
+The SQLite database contains 33 tables organized by category. The complete schema is defined in [garmin_health_data/tables.ddl](garmin_health_data/tables.ddl) following the same pattern as the [openetl project](https://github.com/diegoscarabelli/openetl). The schema includes inline documentation comments for all tables and columns, which are preserved in the SQLite database itself:
 
 ```bash
 # View schema for a specific table
@@ -321,15 +315,16 @@ sqlite3 ~/garmin_data.db "SELECT sql FROM sqlite_master WHERE type='table';"
 
 The schema is automatically created when you initialize the database.
 
-### SQLite Adaptations
+<details>
+<summary><strong>SQLite adaptations</strong></summary>
 
-The database schema has been adapted from the original PostgreSQL/TimescaleDB [schema in OpenETL](https://github.com/diegoscarabelli/openetl/blob/main/dags/pipelines/garmin/tables.ddl) to be fully compatible with SQLite, while preserving all relationships and data integrity. Key adaptations include:
+The database schema has been adapted from the original PostgreSQL/TimescaleDB [schema in OpenETL](https://github.com/diegoscarabelli/openetl/blob/main/dags/pipelines/garmin/tables.ddl) to be fully compatible with SQLite, while preserving all relationships and data integrity. Key adaptations:
 
-- **Removed PostgreSQL schemas** - SQLite doesn't support schemas, all tables are in the default namespace.
-- **Converted SERIAL to AUTOINCREMENT** - PostgreSQL `SERIAL` types converted to SQLite `INTEGER PRIMARY KEY AUTOINCREMENT`.
-- **Replaced TimescaleDB hypertables** - Time-series tables use regular SQLite tables with indexes on timestamp columns for efficient queries.
-- **SQLite-compatible upsert syntax** - Uses SQLite's `INSERT ... ON CONFLICT` for handling duplicate records.
-- **JSON over JSONB** - PostgreSQL `JSONB` columns (e.g., `activity_path.path_json`) are stored in SQLite as `JSON`/TEXT. CHECK constraints rely on SQLite JSON functions (`json_valid`, `json_type`, `json_array_length`), which are commonly available in SQLite 3.9+ but depend on the SQLite library bundled with your Python/runtime environment. If `CREATE TABLE` fails with errors about missing `json_valid` or `json_type`, verify JSON support first:
+- **Removed PostgreSQL schemas** — SQLite doesn't support schemas; all tables live in the default namespace.
+- **Converted SERIAL to AUTOINCREMENT** — PostgreSQL `SERIAL` types converted to SQLite `INTEGER PRIMARY KEY AUTOINCREMENT`.
+- **Replaced TimescaleDB hypertables** — time-series tables use regular SQLite tables with indexes on timestamp columns for efficient queries.
+- **SQLite-compatible upsert syntax** — uses SQLite's `INSERT ... ON CONFLICT` for handling duplicate records.
+- **JSON over JSONB** — PostgreSQL `JSONB` columns (e.g., `activity_path.path_json`) are stored in SQLite as `JSON`/TEXT. CHECK constraints rely on SQLite JSON functions (`json_valid`, `json_type`, `json_array_length`), which are commonly available in SQLite 3.9+ but depend on the SQLite library bundled with your Python/runtime environment. If `CREATE TABLE` fails with errors about missing `json_valid` or `json_type`, verify JSON support first:
 
   ```bash
   python - <<'PY'
@@ -340,20 +335,26 @@ The database schema has been adapted from the original PostgreSQL/TimescaleDB [s
   PY
   ```
 
-- **Preserved all relationships** - All foreign key relationships and table structures maintained.
+- **Preserved all relationships** — all foreign key relationships and table structures maintained.
 
 These adaptations ensure the standalone application maintains complete feature parity with the OpenETL Garmin pipeline while using a zero-configuration SQLite database.
 
-### Table Structure
+</details>
+
+<details>
+<summary><strong>Table structure</strong></summary>
 
 **User & Profile (2 tables)**
+
 ```
 user (root table)
 └── user_profile (fitness profile, physical characteristics)
 ```
+
 *Foreign keys: `user_profile` → `user.user_id`*
 
 **Activities (11 tables)**
+
 ```
 activity (main activity records)
 ├── activity_lap_metric (lap-by-lap metrics)
@@ -367,9 +368,11 @@ activity (main activity records)
 ├── swimming_agg_metrics (swimming-specific aggregates)
 └── supplemental_activity_metric (additional activity metrics)
 ```
+
 *Foreign keys: `activity` → `user.user_id`; all child tables → `activity.activity_id`*
 
 **Sleep Metrics (7 tables)**
+
 ```
 sleep (main sleep sessions)
 ├── sleep_level (discrete sleep stage intervals)
@@ -379,9 +382,11 @@ sleep (main sleep sessions)
 ├── hrv (heart rate variability)
 └── breathing_disruption (breathing events)
 ```
+
 *Foreign keys: `sleep` → `user.user_id`; all child tables → `sleep.sleep_id`*
 
 **Health Time-Series (7 tables)**
+
 ```
 heart_rate (continuous heart rate measurements)
 stress (stress level readings)
@@ -391,23 +396,30 @@ steps (step counts and activity levels)
 floors (floors climbed/descended)
 intensity_minutes (activity intensity tracking)
 ```
+
 *Foreign keys: all tables → `user.user_id`*
 
 **Training Metrics (4 tables)**
+
 ```
 vo2_max (VO2 max estimates)
 acclimation (heat/altitude acclimation)
 training_load (training load metrics)
 training_readiness (daily readiness scores)
 ```
+
 *Foreign keys: all tables → `user.user_id`*
 
 **Records & Predictions (2 tables)**
+
 ```
 personal_record (personal bests)
 race_predictions (predicted race times)
 ```
+
 *Foreign keys: all tables → `user.user_id`. Note: `personal_record.activity_id` column exists but has no FK constraint (allows processing PRs before the linked activity is extracted).*
+
+</details>
 
 ## Privacy & Security
 
@@ -441,106 +453,124 @@ Check out [OpenETL's Garmin pipeline](https://github.com/diegoscarabelli/openetl
 | **Auto-resume** | ✅ | ✅ | ✅ | ✅ | ❌ |
 | **Active maintenance** | ✅ | ✅ | ✅ | ✅ | ⚠️ Limited |
 
-### Schema Comparison: garmin-health-data vs garmindb vs garmy
+<details>
+<summary><strong>Schema deep-dive: garmin-health-data vs garmindb vs garmy</strong></summary>
 
 #### Activity Time-Series Data
 
 **garmin-health-data** uses a flexible EAV (Entity-Attribute-Value) schema in the `activity_ts_metric` table:
+
 - **Schema**: `(activity_id, timestamp, name, value, units)`.
 - **Captures ALL FIT file metrics**: heart rate, power, cadence, GPS coordinates, advanced running dynamics (ground contact time, vertical oscillation, stride length), cycling power metrics (left/right balance, pedal smoothness), swimming metrics, and more.
-- **Future-proof**: Automatically handles any new metrics Garmin adds without requiring schema changes.
-- **Example**: A cycling activity with a power meter captures `power`, `left_right_balance`, `left_pedal_smoothness`, `right_pedal_smoothness`, `left_torque_effectiveness`, `right_torque_effectiveness`, etc.
+- **Future-proof**: automatically handles any new metrics Garmin adds without requiring schema changes.
+- **Example**: a cycling activity with a power meter captures `power`, `left_right_balance`, `left_pedal_smoothness`, `right_pedal_smoothness`, `left_torque_effectiveness`, `right_torque_effectiveness`, etc.
 
 **garmindb** uses a fixed column schema in the `ActivityRecords` table:
+
 - **Only ~10 predefined columns**: `hr`, `cadence`, `speed`, `distance`, `altitude`, `temperature`, `position_lat`, `position_long`, `rr`.
-- **Missing critical data**: No power data, no advanced running/cycling dynamics, no device-specific metrics.
-- **Limited extensibility**: Requires schema changes and code updates to add new metrics.
+- **Missing critical data**: no power data, no advanced running/cycling dynamics, no device-specific metrics.
+- **Limited extensibility**: requires schema changes and code updates to add new metrics.
 
 **garmy** (API-only approach):
+
 - **No per-second activity data**: API provides only aggregated summaries (avg/max HR, duration, training load).
-- **No FIT file access**: Cannot capture detailed time-series metrics that exist only in device files.
+- **No FIT file access**: cannot capture detailed time-series metrics that exist only in device files.
 
 #### Sport-Specific Metrics
 
 **garmin-health-data** provides dedicated tables for each sport:
-- `running_agg_metrics`: Running cadence, vertical oscillation, ground contact time, stride length, VO2 max.
-- `cycling_agg_metrics`: Power metrics (avg/max/normalized), cadence, pedal dynamics, FTP.
-- `swimming_agg_metrics`: Stroke count, SWOLF, pool length, stroke type.
-- `strength_exercise`: Per-exercise aggregates (sets, reps, volume, duration, max weight) from the activities list.
-- `strength_set`: Per-set granular data (set type, duration, reps, weight, ML-classified exercise name/category) from the exercise sets API endpoint.
+
+- `running_agg_metrics`: running cadence, vertical oscillation, ground contact time, stride length, VO2 max.
+- `cycling_agg_metrics`: power metrics (avg/max/normalized), cadence, pedal dynamics, FTP.
+- `swimming_agg_metrics`: stroke count, SWOLF, pool length, stroke type.
+- `strength_exercise`: per-exercise aggregates (sets, reps, volume, duration, max weight) from the activities list.
+- `strength_set`: per-set granular data (set type, duration, reps, weight, ML-classified exercise name/category) from the exercise sets API endpoint.
 
 **garmindb** uses activity-type tables:
-- `StepsActivities`, `PaddleActivities`, `CycleActivities`, `ClimbingActivities`
-- Less comprehensive sport-specific metrics
+
+- `StepsActivities`, `PaddleActivities`, `CycleActivities`, `ClimbingActivities`.
+- Less comprehensive sport-specific metrics.
 
 **garmy** uses basic activity records:
-- `activities`: Simple table with activity name, duration, avg HR, training load.
+
+- `activities`: simple table with activity name, duration, avg HR, training load.
 - **No sport-specific metrics**: API doesn't provide detailed power/cadence/dynamics data.
 
 #### Sleep Data Granularity
 
 **garmin-health-data** provides comprehensive sleep tracking with 7 tables:
-- `sleep`: Main sleep session with scores and metadata.
-- `sleep_level`: Variable-length intervals classifying each segment of the night as Deep, Light, REM, or Awake.
+
+- `sleep`: main sleep session with scores and metadata.
+- `sleep_level`: variable-length intervals classifying each segment of the night as Deep, Light, REM, or Awake.
 - `sleep_movement`: 1-minute interval movement data throughout sleep.
 - `hrv`: 5-minute interval heart rate variability measurements.
 - `spo2`: 1-minute interval blood oxygen saturation.
-- `breathing_disruption`: Event-based breathing disruption timestamps.
-- `sleep_restless_moment`: Event-based restless moment timestamps.
+- `breathing_disruption`: event-based breathing disruption timestamps.
+- `sleep_restless_moment`: event-based restless moment timestamps.
 
 **garmindb** uses only 2 tables:
-- `Sleep`: Main sleep session data.
-- `SleepEvents`: Sleep events (less granular than garmin-health-data's separate time-series tables).
+
+- `Sleep`: main sleep session data.
+- `SleepEvents`: sleep events (less granular than garmin-health-data's separate time-series tables).
 
 **garmy** uses 1 table with daily aggregates:
-- `daily_health_metrics`: Single row per day with summary columns (total hours, deep/light/REM percentages).
-- **No per-minute data**: Cannot analyze sleep cycles, movement patterns, or SpO2 fluctuations throughout the night.
+
+- `daily_health_metrics`: single row per day with summary columns (total hours, deep/light/REM percentages).
+- **No per-minute data**: cannot analyze sleep cycles, movement patterns, or SpO2 fluctuations throughout the night.
 
 #### Health Time-Series Organization
 
 **garmin-health-data** uses separate normalized tables for each metric type:
+
 - Each metric type (`heart_rate`, `stress`, `body_battery`, `respiration`, `steps`, `floors`, `intensity_minutes`) has its own table.
 - Consistent schema: `(user_id, timestamp, value)` plus metric-specific fields.
 - Optimized for time-series queries and analysis.
 
 **garmindb** uses a mixed approach:
+
 - Some monitoring tables for specific metrics.
 - Wide `DailySummary` table containing many aggregated metrics in a single row.
 - Less optimized for granular time-series analysis.
 
 **garmy** uses normalized tables optimized for API sync:
-- `daily_health_metrics`: Wide table (~50 columns) for daily summaries.
-- `timeseries`: High-frequency data when available from API (heart rate, stress, body battery).
-- `sync_status`: Tracks which metrics have been synced for each date.
+
+- `daily_health_metrics`: wide table (~50 columns) for daily summaries.
+- `timeseries`: high-frequency data when available from API (heart rate, stress, body battery).
+- `sync_status`: tracks which metrics have been synced for each date.
 
 #### Update Strategy & Data Integrity
 
 **garmin-health-data** uses explicit conflict resolution for idempotent reprocessing:
-- **Updatable data** (activities, user profile, training status): Uses `ON CONFLICT UPDATE` to refresh data when reprocessing.
-- **Immutable time-series** (heart rate, sleep movement, stress): Uses `ON CONFLICT DO NOTHING` to prevent duplicates.
-- **FIT activity metrics** (time-series, laps, splits): Uses delete+insert for idempotent reprocessing. The `ts_data_available` flag tracks time-series data availability.
-- **Latest flags**: Manages `latest=True` flags for `user_profile`, `personal_record`, `race_predictions` to track most recent values.
-- **Referential integrity**: Explicit foreign key relationships with cascade deletes.
-- **Fully idempotent**: Safe to reprocess the same date range multiple times without creating duplicate data.
+
+- **Updatable data** (activities, user profile, training status): uses `ON CONFLICT UPDATE` to refresh data when reprocessing.
+- **Immutable time-series** (heart rate, sleep movement, stress): uses `ON CONFLICT DO NOTHING` to prevent duplicates.
+- **FIT activity metrics** (time-series, laps, splits): uses delete+insert for idempotent reprocessing. The `ts_data_available` flag tracks time-series data availability.
+- **Latest flags**: manages `latest=True` flags for `user_profile`, `personal_record`, `race_predictions` to track most recent values.
+- **Referential integrity**: explicit foreign key relationships with cascade deletes.
+- **Fully idempotent**: safe to reprocess the same date range multiple times without creating duplicate data.
 
 **garmindb** update strategy:
+
 - Uses SQLAlchemy `session.merge()` operations via `insert_or_update()` and `s_insert_or_update()` methods.
 - Handles duplicates at the ORM level rather than explicit SQL constraints.
 - Implementation detail not documented in README or schema documentation.
 - Idempotency behavior exists but is implicit rather than guaranteed at database level.
 
 **garmy** update strategy:
+
 - Uses SQLAlchemy `session.merge()` for upserts + `sync_status` table for tracking.
-- **Sync-aware**: Tracks which metrics have been synced for each date to avoid redundant API calls.
-- **Status tracking**: Records `pending`, `completed`, `failed`, or `skipped` status per metric/date.
+- **Sync-aware**: tracks which metrics have been synced for each date to avoid redundant API calls.
+- **Status tracking**: records `pending`, `completed`, `failed`, or `skipped` status per metric/date.
+
+</details>
 
 ## Contributing
 
 Contributions are welcome! Please note:
 
-- **Data extraction and processing logic** is synchronized with the [openetl Garmin pipeline](https://github.com/diegoscarabelli/openetl/tree/main/dags/pipelines/garmin)
-- **For changes to extraction/processing logic**, please contribute to openetl first, as this application is a wrapper that provides a standalone CLI
-- **For CLI-specific features, documentation, or packaging improvements**, feel free to contribute directly here
+- **Data extraction and processing logic** is synchronized with the [openetl Garmin pipeline](https://github.com/diegoscarabelli/openetl/tree/main/dags/pipelines/garmin).
+- **For changes to extraction/processing logic**, please contribute to openetl first, as this application is a wrapper that provides a standalone CLI.
+- **For CLI-specific features, documentation, or packaging improvements**, feel free to contribute directly here.
 
 Please feel free to submit a Pull Request.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ garmin extract
 garmin info
 ```
 
-That's it! Your data is now in a local SQLite database (`garmin_data.db`).
+That's it! `garmin extract` saved your raw downloaded files under `garmin_files/storage/` (kept on disk as an offline backup) and loaded them into a local SQLite database (`garmin_data.db`) for analysis.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![CI](https://github.com/diegoscarabelli/garmin-health-data/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/diegoscarabelli/garmin-health-data/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Download your complete Garmin Connect health and activity data as local files, then process them into a SQLite database for analysis. Ships a self-contained Garmin Connect client (`garmin_health_data/garmin_client/`) that handles SSO authentication and API access. The well-structured and documented schema makes the database straightforward to analyze, and particularly effective as a data source for AI agents.
+A single CLI command downloads your complete Garmin Connect health and activity data as local files and loads them into a SQLite database for analysis — extract and process in one pass, or split the two stages with `--extract-only` / `--process-only` for backup-only or replay workflows. Ships a self-contained Garmin Connect client (`garmin_health_data/garmin_client/`) that handles SSO authentication and API access. The well-structured and documented schema makes the database straightforward to analyze, and particularly effective as a data source for AI agents.
 
 **Adapted from the Garmin pipeline in [OpenETL](https://github.com/diegoscarabelli/openetl)**, a comprehensive ETL framework with Apache Airflow and PostgreSQL/TimescaleDB. This standalone version of the [OpenETL Garmin data pipeline](https://github.com/diegoscarabelli/openetl/tree/main/dags/pipelines/garmin) provides the same data extraction and modeling scheme without requiring Airflow or PostgreSQL infrastructure.
 
 ## Features
 
-- 🏥 **Comprehensive data**: sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics — plus FIT activity files with detailed time-series, laps, and splits — downloaded as local files, then processed into a single SQLite database.
+- 🏥 **Comprehensive data**: a single `garmin extract` command downloads sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics, and FIT activity files (time-series, laps, splits) as local files and loads them into a SQLite database in one pass.
 - 👥 **Multi-account**: one database across multiple Garmin Connect accounts (e.g. family members). Run `garmin auth` once per account; extraction discovers and processes them automatically.
 - 🛡️ **Resilient pipeline**: four-folder lifecycle (`ingest/process/storage/quarantine`), auto-resume from the last update, crash recovery, and per-date / per-data-type / per-activity / per-FileSet failure isolation. Original files are preserved on disk for offline backup and post-mortem inspection.
 - 🔐 **Self-contained Garmin client**: bundled SSO/MFA login client, no third-party dependency for API access.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/diegoscarabelli/garmin-health-data/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/diegoscarabelli/garmin-health-data/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Extract your complete Garmin Connect health and activity data to a local SQLite database. Ships a self-contained Garmin Connect client (`garmin_health_data/garmin_client/`) that handles SSO authentication and API access. The well-structured and documented schema makes the database straightforward to analyze, and particularly effective as a data source for AI agents.
+Download your complete Garmin Connect health and activity data as local files, then process them into a SQLite database for analysis. Ships a self-contained Garmin Connect client (`garmin_health_data/garmin_client/`) that handles SSO authentication and API access. The well-structured and documented schema makes the database straightforward to analyze, and particularly effective as a data source for AI agents.
 
 **Adapted from the Garmin pipeline in [OpenETL](https://github.com/diegoscarabelli/openetl)**, a comprehensive ETL framework with Apache Airflow and PostgreSQL/TimescaleDB. This standalone version of the [OpenETL Garmin data pipeline](https://github.com/diegoscarabelli/openetl/tree/main/dags/pipelines/garmin) provides the same data extraction and modeling scheme without requiring Airflow or PostgreSQL infrastructure.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A single CLI command downloads your complete Garmin Connect health and activity 
 - 🏥 **Comprehensive data**: a single `garmin extract` command downloads sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics, and FIT activity files (time-series, laps, splits) as local files and loads them into a SQLite database in one pass.
 - 👥 **Multi-account**: one database across multiple Garmin Connect accounts (e.g. family members). Run `garmin auth` once per account; extraction discovers and processes them automatically.
 - 🛡️ **Resilient pipeline**: four-folder lifecycle (`ingest/process/storage/quarantine`), auto-resume from the last update, crash recovery, and per-date / per-data-type / per-activity / per-FileSet failure isolation. Original files are preserved on disk for offline backup and post-mortem inspection.
-- 🔐 **Self-contained Garmin client**: bundled SSO/MFA login client, no third-party dependency for API access.
+- 🔐 **Self-contained Garmin client**: bundled SSO/MFA login client, with no third-party Garmin Connect client library dependency.
 - 🖥️ **Cross-platform**: macOS, Linux, Windows. Python 3.10+.
 
 ## Requirements
@@ -82,7 +82,7 @@ Tokens are stored in per-account subdirectories and discovered automatically:
 
 All discovered accounts are extracted sequentially when running `garmin extract`, with per-account error isolation (one failing account doesn't block others).
 
-> Login strategies, token rotation, and the 30-45s anti-rate-limit pause: see [Authentication internals](#reference).
+> Login strategies, token rotation, and the 30-45s anti-rate-limit pause: see [Reference](#reference).
 
 ### Extracting data
 
@@ -159,7 +159,7 @@ Last Update Dates:
 # Check a specific database
 garmin info --db-path ~/my-garmin-data.db
 
-# Verify database integrity (table count + SQLite PRAGMA integrity_check)
+# Verify database integrity (expected schema table count + SQLite PRAGMA integrity_check)
 garmin verify
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Download your complete Garmin Connect health and activity data as local files, t
 
 ## Features
 
-- 🏥 **Comprehensive data**: sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics — plus FIT activity files with detailed time-series, laps, and splits — into a single local SQLite database.
+- 🏥 **Comprehensive data**: sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics — plus FIT activity files with detailed time-series, laps, and splits — downloaded as local files, then processed into a single SQLite database.
 - 👥 **Multi-account**: one database across multiple Garmin Connect accounts (e.g. family members). Run `garmin auth` once per account; extraction discovers and processes them automatically.
 - 🛡️ **Resilient pipeline**: four-folder lifecycle (`ingest/process/storage/quarantine`), auto-resume from the last update, crash recovery, and per-date / per-data-type / per-activity / per-FileSet failure isolation. Original files are preserved on disk for offline backup and post-mortem inspection.
 - 🔐 **Self-contained Garmin client**: bundled SSO/MFA login client, no third-party dependency for API access.


### PR DESCRIPTION
## Summary

Reorganises the README so a first-time reader sees a tight narrative ("install → auth → extract → query") and the deep-reference material (every flag, every SQLite quirk, every per-tool schema comparison) lives behind collapsibles.

**Every piece of original content is preserved** — verbatim where possible. This is a reorganisation, not a content cut.

## Structural changes

- **Features**: 10 bullets → 5. Drops marketing-style "Zero Configuration" / "Cross-Platform" (already in Requirements + Quick Start), merges duplicative bullets describing the same capability.
- **Usage** (~230 lines → ~80 lines): narrative only — auth, extracting, common workflows, inspecting your data.
- **Reference** (new top-level): full flag table + 5 collapsible blocks (file lifecycle, failure handling & retries, date handling & auto-detection, authentication internals, duplicate prevention).
- **Data Catalog** (replaces Data Types + Database Schema): data types table + schema overview visible; SQLite adaptations and table-structure deep dive collapsed.
- **Comparison with Other Tools** (kept at the bottom per your preference): narrative paragraphs + feature comparison table visible; the 5 head-to-head schema deep-dives (~95 lines) collapsed under one `<details>` block.
- **Cuts**: duplicate `Data Types` subsection inside Usage; redundant `garmin extract` examples appearing in both Quick Start and Usage.

## Accuracy pass against the code

I cross-checked every factual claim in the new README against the actual code (`cli.py`, `lifecycle.py`, `extractor.py`, `auth.py`, `tokens.py`, `constants.py`, `tables.ddl`, `pyproject.toml`). One omission found and fixed:

- **Added the `garmin verify` command**, which runs `PRAGMA integrity_check` and reports the table count. Wasn't in the previous README.

Verified accurate: 4-attempt retry loop with 2s/8s/30s backoff, 4-level failure isolation, 5-strategy SSO login order, ~18h access / 30-day refresh token lifecycle, `fcntl.flock` advisory lock with Windows no-op fallback, 33-table schema (User & Profile 2, Activities 11, Sleep 7, Health 7, Training 4, Records 2), 15 data types in the registry, auto-detection 30-day fallback + max-date logic across 10 core tables.

## Notes

- Net size: 550 → 580 lines on disk (small growth from `<details>` markup), but ~330 lines visible on first scroll instead of 550.
- `<details>` blocks render fine on github.com but flatten to plain text on PyPI's rendering — same effect as today (PyPI page stays scrollable).

## Test plan

- [ ] Skim the rendered README on GitHub: does the narrative read cleanly without expanding any `<details>`?
- [ ] Expand each `<details>` block in turn: does the deep-reference content still make sense in isolation?
- [ ] Verify on the PR preview that nothing important got cut (compare against `main` README side-by-side).