### PR TITLE
fix(extract): preserve per-account partial failures on account-level crash (v2.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.2] - 2026-04-28
+
+### Fixed
+
+- **Per-account partial failures dropped on account-level crash** in the multi-account `extract()` loop. `all_failures.extend(extractor.failures)` lived inside the `try` block on the success path only, so any per-date / per-data-type / per-activity failures captured BEFORE an account-level crash (e.g. an exception in `extract_fit_activities` after `extract_garmin_data` already recorded several per-day failures) were silently lost from the end-of-run summary. The merge moves to a `finally:` block so partial failures are always preserved, regardless of whether the account also crashed. Mirrors the same fix already in place in the openetl Garmin pipeline. New regression test (`test_partial_failures_preserved_when_account_crashes`) guards against the regression.
+
 ## [2.7.1] - 2026-04-28
 
 ### Fixed
@@ -298,7 +304,8 @@ All data can be re-downloaded from Garmin Connect. This is the cleanest upgrade 
 - Flexible authentication with OAuth tokens.
 - Comprehensive documentation and examples.
 
-[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.1...HEAD
+[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.2...HEAD
+[2.7.2]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.6.1...v2.7.0
 [2.6.1]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.6.0...v2.6.1

--- a/garmin_health_data/__version__.py
+++ b/garmin_health_data/__version__.py
@@ -2,4 +2,4 @@
 Version information for garmin-health-data.
 """
 
-__version__ = "2.7.1"
+__version__ = "2.7.2"

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -988,6 +988,7 @@ def extract(
     failed_accounts = []
 
     for user_id, token_dir in discovered:
+        extractor: Optional[GarminExtractor] = None
         try:
             click.echo()
             click.echo(
@@ -1015,7 +1016,6 @@ def extract(
 
             all_garmin_files.extend(garmin_files)
             all_activity_files.extend(activity_files)
-            all_failures.extend(extractor.failures)
 
         except Exception:
             logger.exception(
@@ -1026,6 +1026,16 @@ def extract(
                 fg="red",
             )
             failed_accounts.append(user_id)
+        finally:
+            # Always merge per-account ExtractionFailures so granular per-date /
+            # per-data-type / per-activity failures recorded BEFORE an
+            # account-level crash still appear in the end-of-run summary.
+            # Without this, a partial run that captured 5 per-day failures and
+            # then crashed in extract_fit_activities would lose those 5 from
+            # the summary. `extractor` is None if the constructor itself
+            # raised, in which case there's nothing to merge.
+            if extractor is not None:
+                all_failures.extend(extractor.failures)
 
     # Check if any data was extracted.
     if not all_garmin_files and not all_activity_files:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garmin-health-data"
-version = "2.7.1"
+version = "2.7.2"
 description = "Extract your Garmin Connect health data to a local SQLite database"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -477,6 +477,56 @@ class TestExtractMultiAccount:
         # Both accounts failed; both should be in failed_accounts.
         assert len(result["failed_accounts"]) > 0
 
+    @patch("garmin_health_data.auth.discover_accounts")
+    @patch("garmin_health_data.extractor.GarminExtractor")
+    def test_partial_failures_preserved_when_account_crashes(
+        self, mock_extractor_class, mock_discover
+    ):
+        """
+        Per-date / per-data-type / per-activity failures recorded BEFORE an account-
+        level crash must still appear in the merged ``failures`` list.
+
+        Without the ``finally:`` merge, those granular failures would be
+        dropped when the account also raises a fatal exception, so the
+        end-of-run summary would only show "account failed" without the
+        per-day detail captured before the crash.
+        """
+
+        mock_discover.return_value = [("11111111", Path("/tokens/11111111"))]
+
+        from garmin_health_data.extractor import ExtractionFailure
+
+        mock_extractor = MagicMock()
+        mock_extractor.failures = [
+            ExtractionFailure(
+                data_type="SLEEP",
+                date="2025-01-01",
+                activity_id="",
+                error="GarminConnectionError: 503",
+            ),
+            ExtractionFailure(
+                data_type="SLEEP",
+                date="2025-01-02",
+                activity_id="",
+                error="GarminConnectionError: 503",
+            ),
+        ]
+        # extract_garmin_data succeeds (returns nothing) but
+        # extract_fit_activities raises after partial failures were recorded.
+        mock_extractor.extract_garmin_data.return_value = []
+        mock_extractor.extract_fit_activities.side_effect = RuntimeError(
+            "FIT download crashed mid-account"
+        )
+        mock_extractor_class.return_value = mock_extractor
+
+        result = extract(Path("/tmp/test"), "2025-01-01", "2025-01-03")
+
+        # Account-level crash recorded.
+        assert "11111111" in result["failed_accounts"]
+        # Pre-crash granular failures preserved (the bug fix).
+        assert len(result["failures"]) == 2
+        assert {f.date for f in result["failures"]} == {"2025-01-01", "2025-01-02"}
+
 
 def _make_zip(inner_filename: str, content: bytes) -> bytes:
     """


### PR DESCRIPTION
## Summary

The multi-account `extract()` loop in `extractor.py` (lines 990-1028 on main) merged each per-account extractor's `failures` list into the run-wide `all_failures` only on the success path (`all_failures.extend(extractor.failures)` lived inside the `try`, after `extract_fit_activities` returned). If an account-level exception fired *before* that line — e.g. `extract_fit_activities` crashed after `extract_garmin_data` had already recorded several per-day failures — the partial failures were silently dropped, and the end-of-run summary only said \"Account X failed\" without the per-day detail captured before the crash. That's the exact scenario where granular failure info is most useful (it tells you what to retry).

This PR moves the merge to a `finally:` block so partial failures are always preserved, regardless of whether the account also crashed. Mirrors the same pattern already in place in the openetl Garmin pipeline. `extractor` is initialised to `None` at the top of the loop so a constructor-side exception doesn't trigger `UnboundLocalError` and replace the original exception.

## Test plan

- [x] **New regression test** `test_partial_failures_preserved_when_account_crashes` mocks an extractor that records 2 per-day failures and then raises in `extract_fit_activities`; asserts both partial failures appear in the result alongside the failed-account record.
- [x] Verified the test fails without the fix (`assert 0 == 2` — partial failures dropped) and passes with it.
- [x] Full extract test suite green locally (44 passed).
- [x] Format check clean (black, autoflake, docformatter, sqlfluff).
- [x] Version bumped in BOTH \`__version__.py\` AND \`pyproject.toml\` (don't repeat the v2.7.1 release oversight).
- [x] CHANGELOG \`[2.7.2]\` entry + reference-style links updated.
- [ ] CI green on macOS / Ubuntu / Windows × Python 3.10/3.11/3.12.
- [ ] Tag \`v2.7.2\` + create GitHub Release after merge → auto-publish to PyPI.