### PR TITLE
build(makefile): only allow docformatter exit code 3, not 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ venv:
 
 format: venv
 	$(PYTHON) -m autoflake .
-	$(PYTHON) -m docformatter --in-place . || { ec=$$?; if [ $$ec -eq 1 ] || [ $$ec -eq 3 ]; then true; else exit $$ec; fi; }
+	$(PYTHON) -m docformatter --in-place . || { ec=$$?; if [ $$ec -eq 3 ]; then true; else exit $$ec; fi; }
 	$(PYTHON) -m black -q .
 	$(PYTHON) -m sqlfluff fix -q --disable-progress-bar --processes 0
 


### PR DESCRIPTION
## Summary

The `format` target's docformatter step accepts exit codes `{1, 3}` as non-fatal:

```make
$(PYTHON) -m docformatter --in-place . || { ec=$$?; if [ $$ec -eq 1 ] || [ $$ec -eq 3 ]; then true; else exit $$ec; fi; }
```

But docformatter's exit codes are:
- `0` = no changes needed
- `1` = real error (parse failure, file-not-found)
- `3` = files modified (which is what we want to allow during `--in-place`)

Treating exit `1` as non-fatal silently swallows real docformatter errors during `make format` (which the pre-commit hook runs), so a broken docstring would slip through to commit.

This PR narrows the allow-list to exit `3` only. Real errors now fail the target as intended.

Mirrors the same fix applied to openetl ([PR #135](https://github.com/diegoscarabelli/openetl/pull/135)).

## Notes

Build-only change (Makefile isn't part of the published package), so **no version bump**.

## Test plan

- [ ] Local: `make format` still passes when docformatter modifies files (exit 3)
- [ ] Local: `make format` now fails when docformatter hits a parse error (exit 1)
- [ ] CI: Code Quality Checks job passes