### PR TITLE
fix: prevent docformatter from corrupting user INSERT SQL

### DIFF
--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -313,10 +313,9 @@ class GarminProcessor(Processor):
             # Create minimal user record with conflict handling.
             session.execute(
                 text(
-                    """
-                    INSERT INTO user (user_id, full_name, birth_date) VALUES (:user_id,
-                    NULL, NULL) ON CONFLICT (user_id) DO NOTHING.
-                    """
+                    "INSERT INTO user (user_id, full_name, birth_date) "
+                    "VALUES (:user_id, NULL, NULL) "
+                    "ON CONFLICT (user_id) DO NOTHING"
                 ),
                 {"user_id": int(user_id)},
             )


### PR DESCRIPTION
## Summary

Fixes #44.

The user INSERT in `GarminProcessor` used a triple-quoted string passed to `text(...)`, which `docformatter` misidentified as a docstring and "fixed" by appending a period after `DO NOTHING`. That produced:

```
OperationalError: near ".": syntax error
[SQL: INSERT INTO user (user_id, full_name, birth_date) VALUES (?, NULL, NULL) ON CONFLICT (user_id) DO NOTHING.]
```

whenever `garmin extract` ran against a fresh database with no user row.

The fix converts the SQL to implicitly concatenated regular strings so docformatter leaves it untouched. Verified with `docformatter --diff` (no changes proposed) and the pre-commit format hook (passes).

## Audit

Searched the rest of the codebase for the same class of bug (raw SQL inside triple-quoted strings passed to `text()` / `execute()`). This was the only occurrence; all other `text()` calls wrap scalar defaults or short single-line strings.

## Test plan

- [x] `docformatter --diff garmin_health_data/processor.py` reports no changes
- [x] Pre-commit format hook passes
- [ ] Reporter (or maintainer) verifies `garmin extract` succeeds against an empty DB