### PR TITLE
fix(cli): friendly fallback on missing DB, version hint on bare invocation

### DIFF
--- a/garmin_health_data/cli.py
+++ b/garmin_health_data/cli.py
@@ -84,6 +84,7 @@ def cli(ctx: click.Context):
     # case, so render it here and exit.
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
+        ctx.exit(0)
 
 
 @cli.command()

--- a/garmin_health_data/cli.py
+++ b/garmin_health_data/cli.py
@@ -52,9 +52,10 @@ _TIMESTAMP_REGEX = (
 )
 
 
-@click.group()
+@click.group(invoke_without_command=True)
 @click.version_option(version=__version__)
-def cli():
+@click.pass_context
+def cli(ctx: click.Context):
     """
     Garmin Connect health data extraction tool.
 
@@ -77,6 +78,12 @@ def cli():
     # via GARMIN_NO_VERSION_CHECK=1, never blocks more than ~2s, never aborts
     # the user's command.
     check_for_newer_version()
+
+    # invoke_without_command=True is set so the version check above fires on
+    # bare `garmin` too. Click no longer prints help automatically in that
+    # case, so render it here and exit.
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @cli.command()
@@ -618,18 +625,19 @@ def _print_extraction_failures(failures: list) -> None:
 @cli.command()
 @click.option(
     "--db-path",
-    type=click.Path(exists=True),
+    type=click.Path(),
     default="garmin_data.db",
     help="Path to SQLite database file.",
 )
-def info(db_path: str):
+@click.pass_context
+def info(ctx: click.Context, db_path: str):
     """
     Show database statistics and information.
     """
     if not database_exists(db_path):
         click.secho(f"❌ Database not found: {db_path}", fg="red")
-        click.echo("   Run 'garmin extract' to create a new database")
-        return
+        click.echo("   Run 'garmin extract' to create a new database.")
+        ctx.exit(1)
 
     click.echo()
     click.echo(
@@ -677,17 +685,19 @@ def info(db_path: str):
 @cli.command()
 @click.option(
     "--db-path",
-    type=click.Path(exists=True),
+    type=click.Path(),
     default="garmin_data.db",
     help="Path to SQLite database file.",
 )
-def verify(db_path: str):
+@click.pass_context
+def verify(ctx: click.Context, db_path: str):
     """
     Verify database integrity and structure.
     """
     if not database_exists(db_path):
         click.secho(f"❌ Database not found: {db_path}", fg="red")
-        return
+        click.echo("   Run 'garmin extract' to create a new database.")
+        ctx.exit(1)
 
     click.echo()
     click.echo(click.style("🔍 Verifying database...", fg="cyan", bold=True))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,7 +48,8 @@ def test_verify_runs_integrity_check(tmp_path):
 
 def test_verify_nonexistent_db(tmp_path):
     """
-    Test that verify command rejects non-existent database path.
+    Test that verify command rejects non-existent database path with a friendly message
+    (rather than Click's raw "does not exist" path-validator error).
     """
     db_path = tmp_path / "nonexistent.db"
 
@@ -56,7 +57,8 @@ def test_verify_nonexistent_db(tmp_path):
     result = runner.invoke(verify, ["--db-path", str(db_path)])
 
     assert result.exit_code != 0
-    assert "does not exist" in result.output
+    assert "Database not found" in result.output
+    assert "garmin extract" in result.output
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,7 +56,7 @@ def test_verify_nonexistent_db(tmp_path):
     runner = CliRunner()
     result = runner.invoke(verify, ["--db-path", str(db_path)])
 
-    assert result.exit_code != 0
+    assert result.exit_code == 1
     assert "Database not found" in result.output
     assert "garmin extract" in result.output
 


### PR DESCRIPTION
Two small UX fixes in `cli.py`:

## 1. `garmin info` / `garmin verify` on a missing DB

Previously these commands rejected a missing default DB at the Click validator (`type=click.Path(exists=True)`), producing:

```
Error: Invalid value for '--db-path': Path 'garmin_data.db' does not exist.
```

The function body already contained a friendlier fallback (`❌ Database not found: ... Run 'garmin extract' to create a new database`), but it was unreachable because the validator fired first. This PR drops `exists=True` so the friendly path runs, and uses `ctx.exit(1)` so scripts can still detect the failure (preserves the exit-code contract that `test_verify_nonexistent_db` was checking).

`verify` previously didn't show the "Run `garmin extract`" hint; now it matches `info`.

## 2. PyPI upgrade hint on bare `garmin`

The new-version hint is wired into the `@click.group()` callback. Click skips the callback when no subcommand is given, so `garmin` alone never showed the hint, only `garmin info` / `garmin extract` / etc. did.

Adds `invoke_without_command=True` so the callback runs in that case too. Help is rendered manually when no subcommand is present, preserving the existing user-visible behavior (now plus the upgrade hint when applicable).

## Test plan

- [x] `test_verify_nonexistent_db` updated and passing (new message + hint asserted)
- [x] Full pytest suite: 182 passed, 1 skipped
- [x] Manual smoke (via `CliRunner`): bare `garmin` shows help, `garmin info` / `garmin verify` on missing DB show the friendly message and exit 1, `garmin --version` unchanged.