### PR TITLE
release: 2.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.4] - 2026-04-30
+
+### Fixed
+
+- **`garmin info` and `garmin verify` rejected a missing default database with an unhelpful Click validator error** (`Invalid value for '--db-path': Path 'garmin_data.db' does not exist.`). The function bodies already contained a friendlier "Database not found, run `garmin extract`" fallback, but it was unreachable because `type=click.Path(exists=True)` rejected the input first. The `exists=True` constraint has been removed so the in-function check runs; both commands now exit 1 (so scripts can detect the failure) and both print the "run `garmin extract`" hint (previously only `info` did). Fixed in #47.
+- **PyPI new-version hint did not appear on bare `garmin`.** The version check is wired into the `@click.group()` callback, which Click does not invoke when no subcommand is supplied. Added `invoke_without_command=True` so the hint fires on bare invocations as well; help is rendered manually in that case to preserve the existing user-visible behavior. Fixed in #47.
+
 ## [2.7.3] - 2026-04-30
 
 ### Fixed
@@ -310,7 +317,8 @@ All data can be re-downloaded from Garmin Connect. This is the cleanest upgrade 
 - Flexible authentication with OAuth tokens.
 - Comprehensive documentation and examples.
 
-[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.3...HEAD
+[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.4...HEAD
+[2.7.4]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.3...v2.7.4
 [2.7.3]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.2...v2.7.3
 [2.7.2]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.7.0...v2.7.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,25 @@ When adding new data processors:
 - Handle NULL values and missing data gracefully.
 - Use upsert patterns for deduplication.
 
+### Raw SQL Strings (docformatter Footgun)
+
+Do **not** pass triple-quoted string literals to `sqlalchemy.text(...)` or any other raw-SQL execution path. `docformatter` (configured in `pyproject.toml` and run via the pre-commit `format` hook) treats triple-quoted strings as docstrings in some contexts and "normalizes" them by appending a period to the first sentence, which corrupts the SQL (e.g. `... DO NOTHING` becomes `... DO NOTHING.`, producing an `OperationalError` at runtime). This shipped as a real bug in #44, fixed in #45.
+
+Use implicitly concatenated regular string literals instead:
+
+```python
+session.execute(
+    text(
+        "INSERT INTO user (user_id, full_name, birth_date) "
+        "VALUES (:user_id, NULL, NULL) "
+        "ON CONFLICT (user_id) DO NOTHING"
+    ),
+    {"user_id": int(user_id)},
+)
+```
+
+If a SQL statement is genuinely too long for that style, move it into a module-level constant assigned from `textwrap.dedent("""...""")` rather than passing the triple-quoted string directly to `text(...)`. Per-row code paths against an empty database are not exercised by the default test suite, so a docformatter-induced corruption can ship undetected.
+
 ## CLI Development
 
 When modifying CLI commands:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,22 +146,7 @@ When adding new data processors:
 
 ### Raw SQL Strings (docformatter Footgun)
 
-Do **not** pass triple-quoted string literals to `sqlalchemy.text(...)` or any other raw-SQL execution path. `docformatter` (configured in `pyproject.toml` and run via the pre-commit `format` hook) treats triple-quoted strings as docstrings in some contexts and "normalizes" them by appending a period to the first sentence, which corrupts the SQL (e.g. `... DO NOTHING` becomes `... DO NOTHING.`, producing an `OperationalError` at runtime). This shipped as a real bug in #44, fixed in #45.
-
-Use implicitly concatenated regular string literals instead:
-
-```python
-session.execute(
-    text(
-        "INSERT INTO user (user_id, full_name, birth_date) "
-        "VALUES (:user_id, NULL, NULL) "
-        "ON CONFLICT (user_id) DO NOTHING"
-    ),
-    {"user_id": int(user_id)},
-)
-```
-
-If a SQL statement is genuinely too long for that style, move it into a module-level constant assigned from `textwrap.dedent("""...""")` rather than passing the triple-quoted string directly to `text(...)`. Per-row code paths against an empty database are not exercised by the default test suite, so a docformatter-induced corruption can ship undetected.
+Don't pass triple-quoted strings to `sqlalchemy.text(...)`: `docformatter` may treat them as docstrings and append a period (`DO NOTHING` becomes `DO NOTHING.`), corrupting the SQL. Use implicitly concatenated regular string literals instead. See #44 / #45.
 
 ## CLI Development
 

--- a/garmin_health_data/__version__.py
+++ b/garmin_health_data/__version__.py
@@ -2,4 +2,4 @@
 Version information for garmin-health-data.
 """
 
-__version__ = "2.7.3"
+__version__ = "2.7.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garmin-health-data"
-version = "2.7.3"
+version = "2.7.4"
 description = "Extract your Garmin Connect health data to a local SQLite database"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Patch release bundling the CLI UX fixes from #47, plus a CLAUDE.md note about the `docformatter` + triple-quoted SQL footgun behind #44.

## Changes

- Bump `version` to `2.7.4` in `pyproject.toml` and `garmin_health_data/__version__.py`.
- `CHANGELOG.md`: add `[2.7.4]` section covering both UX fixes from #47.
- `CLAUDE.md`: new "Raw SQL Strings (docformatter Footgun)" subsection under "Data Processing Patterns" so future contributors (and AI agents) don't reintroduce the #44 bug shape.

## Release notes

**Fixed**
- `garmin info` and `garmin verify` now print a friendly "Database not found, run `garmin extract`" message and exit 1 when the default DB is missing, instead of being rejected by Click's path validator with `Invalid value for --db-path: Path 'garmin_data.db' does not exist.` (#47).
- The PyPI new-version hint now also fires on bare `garmin` (no subcommand). Previously it only ran when a subcommand was supplied (#47).