### PR TITLE
feat: add body composition data type and processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ This means you can safely:
 | **STEPS** | Step counts and activity levels | 15-min intervals |
 | **FLOORS** | Floors climbed and descended | 15-min intervals |
 | **INTENSITY_MINUTES** | Moderate/vigorous activity minutes | 15-min intervals |
+| **BODY_COMPOSITION** | Scale weigh-ins: weight, BMI, body fat %, body water %, bone mass, muscle mass | Per weigh-in |
 | **ACTIVITIES_LIST** | Detailed activity summaries | Per activity |
 | **EXERCISE_SETS** | Per-set strength training data: reps, weight, ML-classified exercise name | Per activity |
 | **PERSONAL_RECORDS** | All-time bests across sports | As achieved |
@@ -304,7 +305,7 @@ This means you can safely:
 
 ### Database Schema
 
-The SQLite database contains 33 tables organized by category. The complete schema is defined in [garmin_health_data/tables.ddl](garmin_health_data/tables.ddl) following the same pattern as the [openetl project](https://github.com/diegoscarabelli/openetl). The schema includes inline documentation comments for all tables and columns, which are preserved in the SQLite database itself:
+The SQLite database contains 34 tables organized by category. The complete schema is defined in [garmin_health_data/tables.ddl](garmin_health_data/tables.ddl) following the same pattern as the [openetl project](https://github.com/diegoscarabelli/openetl). The schema includes inline documentation comments for all tables and columns, which are preserved in the SQLite database itself:
 
 ```bash
 # View schema for a specific table
@@ -386,7 +387,7 @@ sleep (main sleep sessions)
 
 *Foreign keys: `sleep` → `user.user_id`; all child tables → `sleep.sleep_id`*
 
-**Health Time-Series (7 tables)**
+**Health Time-Series (8 tables)**
 
 ```
 heart_rate (continuous heart rate measurements)
@@ -396,6 +397,7 @@ respiration (breathing rate data)
 steps (step counts and activity levels)
 floors (floors climbed/descended)
 intensity_minutes (activity intensity tracking)
+body_composition (scale weigh-ins: weight, BMI, body fat, etc.)
 ```
 
 *Foreign keys: all tables → `user.user_id`*
@@ -430,7 +432,7 @@ race_predictions (predicted race times)
 
 ## Comparison With Other Tools
 
-**[garmin-health-data](https://github.com/diegoscarabelli/garmin-health-data)** is designed for comprehensive data extraction with a well-structured relational schema that supports both human-powered analytics and LLM-powered analysis via agents querying the locally created SQLite file. It extracts complete FIT file data with per-second activity metrics, 1-minute sleep intervals, and sport-specific tables for detailed analysis. The normalized 33-table schema with explicit SQL constraints ensures data integrity and makes it easy to understand relationships for complex queries, power zone analysis, running dynamics, and long-term trend studies.
+**[garmin-health-data](https://github.com/diegoscarabelli/garmin-health-data)** is designed for comprehensive data extraction with a well-structured relational schema that supports both human-powered analytics and LLM-powered analysis via agents querying the locally created SQLite file. It extracts complete FIT file data with per-second activity metrics, 1-minute sleep intervals, and sport-specific tables for detailed analysis. The normalized 34-table schema with explicit SQL constraints ensures data integrity and makes it easy to understand relationships for complex queries, power zone analysis, running dynamics, and long-term trend studies.
 
 **[garmy](https://github.com/bes-dev/garmy)** is optimized for programmatic access to the Garmin Connect API, particularly useful for AI assistant integration via its built-in MCP (Model Context Protocol) server. It enables real-time interaction with Claude Desktop or custom chatbots for quick daily insights and summaries. However, it's limited to API-provided metrics (daily aggregates only, no FIT file access), making deep analytics or granular time-series analysis impossible. Best suited for lightweight health monitoring apps that prioritize AI integration over comprehensive data collection.
 
@@ -449,7 +451,7 @@ Check out [OpenETL's Garmin pipeline](https://github.com/diegoscarabelli/openetl
 | **Sleep data granularity** | ✅ 7 tables, 1-min intervals | ⚠️ 2 tables, less granular | ⚠️ 1 table, daily aggregate | ❌ | ❌ |
 | **FIT file time-series data** | ✅ All metrics (EAV schema) | ⚠️ Limited (~10 core fields) | ❌ API-only (no FIT files) | ❌ | ❌ |
 | **Power meter & advanced metrics** | ✅ Full support | ❌ Not captured | ❌ API limitations | ❌ | ❌ |
-| **Database schema quality** | ✅ Normalized, 33 tables | ⚠️ ~31 tables, mixed normalization | ❌ Very simple | N/A | N/A |
+| **Database schema quality** | ✅ Normalized, 34 tables | ⚠️ ~31 tables, mixed normalization | ❌ Very simple | N/A | N/A |
 | **Duplicate prevention** | ✅ Explicit SQL ON CONFLICT | ⚠️ ORM merge (undocumented) | ✅ ORM merge + sync tracking | N/A | N/A |
 | **Auto-resume** | ✅ | ✅ | ✅ | ✅ | ❌ |
 | **Active maintenance** | ✅ | ✅ | ✅ | ✅ | ⚠️ Limited |

--- a/garmin_health_data/constants.py
+++ b/garmin_health_data/constants.py
@@ -154,6 +154,16 @@ class GarminDataRegistry:
             ),
             # Range Data - Date range parameters: get_method(start_str, end_str)
             GarminDataType(
+                "BODY_COMPOSITION",
+                "get_body_composition",
+                APIMethodTimeParam.RANGE,
+                "/weight-service/weight/daterangesnapshot",
+                "Scale weigh-ins: weight, BMI, body fat %, body water %, bone mass, "
+                "muscle mass, physique rating, visceral fat, metabolic age. Multiple "
+                "entries per day if the user weighs more than once.",
+                "⚖️",
+            ),
+            GarminDataType(
                 "ACTIVITIES_LIST",
                 "get_activities_by_date",
                 APIMethodTimeParam.RANGE,

--- a/garmin_health_data/garmin_client/api.py
+++ b/garmin_health_data/garmin_client/api.py
@@ -235,20 +235,25 @@ def get_intensity_minutes_data(client: "GarminClient", cdate: str) -> Dict[str, 
 
 def get_body_composition(
     client: "GarminClient", startdate: str, enddate: Optional[str] = None
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """
     Fetch scale weigh-ins (weight and body composition) for a date range.
 
     Each entry in ``dateWeightList`` corresponds to a single weigh-in. A user may weigh
-    more than once per day, in which case the API returns multiple entries. Days with no
-    weigh-in return an empty ``dateWeightList``.
+    more than once per day, in which case the API returns multiple entries.
+
+    On days with no weigh-in the Garmin endpoint returns a populated wrapper dict
+    (``startDate``, ``endDate``, an empty ``dateWeightList``, and a ``totalAverage`` of
+    nulls) rather than an empty response. This function normalizes that shape to
+    ``None`` so the extractor's ``if data:`` truthiness check skips the file write,
+    matching the behavior of other RANGE-typed endpoints (e.g. ``ACTIVITIES_LIST``).
 
     :param client: GarminClient instance.
     :param startdate: Start date in ``YYYY-MM-DD`` format.
     :param enddate: Optional end date in ``YYYY-MM-DD`` format. Defaults to
         ``startdate``.
     :return: Snapshot dictionary with ``dateWeightList`` (one entry per weigh-in) and
-        ``totalAverage`` aggregates.
+        ``totalAverage`` aggregates, or ``None`` if no weigh-ins were recorded.
     """
     startdate = _validate_date_format(startdate, "startdate")
     if enddate is None:
@@ -256,7 +261,10 @@ def get_body_composition(
     else:
         enddate = _validate_date_format(enddate, "enddate")
     params = {"startDate": startdate, "endDate": enddate}
-    return client._connectapi(WEIGHT_DATERANGE_URL, params=params)
+    result = client._connectapi(WEIGHT_DATERANGE_URL, params=params)
+    if result and result.get("dateWeightList"):
+        return result
+    return None
 
 
 # ----------------------------------------------------------------------------------------

--- a/garmin_health_data/garmin_client/api.py
+++ b/garmin_health_data/garmin_client/api.py
@@ -12,7 +12,8 @@ library; URL templates live in :mod:`.constants`.
 The 15 supported endpoints:
 
 - Daily wellness:        sleep, stress, respiration, heart_rates, training_readiness,
-                         training_status, steps, floors, intensity_minutes
+                         training_status, steps, floors, intensity_minutes,
+                         body_composition
 - Range activities:      activities_by_date (paginated), activity_exercise_sets
 - No-date metadata:      personal_records, race_predictions, user_profile
 - Binary download:       download_activity (FIT/TCX/GPX/KML/CSV)
@@ -43,6 +44,7 @@ from .constants import (
     TRAINING_STATUS_URL,
     USER_SETTINGS_URL,
     USER_SUMMARY_CHART_URL,
+    WEIGHT_DATERANGE_URL,
 )
 
 if TYPE_CHECKING:
@@ -229,6 +231,32 @@ def get_intensity_minutes_data(client: "GarminClient", cdate: str) -> Dict[str, 
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{DAILY_INTENSITY_MINUTES_URL}/{cdate}"
     return client._connectapi(url)
+
+
+def get_body_composition(
+    client: "GarminClient", startdate: str, enddate: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Fetch scale weigh-ins (weight and body composition) for a date range.
+
+    Each entry in ``dateWeightList`` corresponds to a single weigh-in. A user may weigh
+    more than once per day, in which case the API returns multiple entries. Days with no
+    weigh-in return an empty ``dateWeightList``.
+
+    :param client: GarminClient instance.
+    :param startdate: Start date in ``YYYY-MM-DD`` format.
+    :param enddate: Optional end date in ``YYYY-MM-DD`` format. Defaults to
+        ``startdate``.
+    :return: Snapshot dictionary with ``dateWeightList`` (one entry per weigh-in) and
+        ``totalAverage`` aggregates.
+    """
+    startdate = _validate_date_format(startdate, "startdate")
+    if enddate is None:
+        enddate = startdate
+    else:
+        enddate = _validate_date_format(enddate, "enddate")
+    params = {"startDate": startdate, "endDate": enddate}
+    return client._connectapi(WEIGHT_DATERANGE_URL, params=params)
 
 
 # ----------------------------------------------------------------------------------------

--- a/garmin_health_data/garmin_client/api.py
+++ b/garmin_health_data/garmin_client/api.py
@@ -1,7 +1,7 @@
 """
 API method implementations for the vendored Garmin Connect client.
 
-Each function here corresponds to one of the 15 Garmin Connect endpoints the
+Each function here corresponds to one of the 16 Garmin Connect endpoints the
 openetl pipeline consumes. The functions are written as plain functions taking
 the ``GarminClient`` instance as their first argument so that the client class
 can stay slim, and so that the file is testable in isolation.
@@ -9,12 +9,12 @@ can stay slim, and so that the file is testable in isolation.
 Method-to-endpoint mapping is inherited from the upstream ``python-garminconnect``
 library; URL templates live in :mod:`.constants`.
 
-The 15 supported endpoints:
+The 16 supported endpoints:
 
 - Daily wellness:        sleep, stress, respiration, heart_rates, training_readiness,
-                         training_status, steps, floors, intensity_minutes,
+                         training_status, steps, floors, intensity_minutes
+- Range data:            activities_by_date (paginated), activity_exercise_sets,
                          body_composition
-- Range activities:      activities_by_date (paginated), activity_exercise_sets
 - No-date metadata:      personal_records, race_predictions, user_profile
 - Binary download:       download_activity (FIT/TCX/GPX/KML/CSV)
 """

--- a/garmin_health_data/garmin_client/client.py
+++ b/garmin_health_data/garmin_client/client.py
@@ -899,6 +899,14 @@ class GarminClient:
         """
         return api.get_intensity_minutes_data(self, cdate)
 
+    def get_body_composition(
+        self, startdate: str, enddate: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        See :func:`api.get_body_composition`.
+        """
+        return api.get_body_composition(self, startdate, enddate)
+
     def get_activities_by_date(
         self,
         startdate: str,

--- a/garmin_health_data/garmin_client/constants.py
+++ b/garmin_health_data/garmin_client/constants.py
@@ -111,6 +111,9 @@ USER_SUMMARY_CHART_URL = "/wellness-service/wellness/dailySummaryChart"
 FLOORS_CHART_DAILY_URL = "/wellness-service/wellness/floorsChartData/daily"
 DAILY_INTENSITY_MINUTES_URL = "/wellness-service/wellness/daily/im"
 
+# Weight / body composition.
+WEIGHT_DATERANGE_URL = "/weight-service/weight/daterangesnapshot"
+
 # Metrics endpoints.
 TRAINING_READINESS_URL = "/metrics-service/metrics/trainingreadiness"
 TRAINING_STATUS_URL = "/metrics-service/metrics/trainingstatus/aggregated"

--- a/garmin_health_data/models.py
+++ b/garmin_health_data/models.py
@@ -780,6 +780,31 @@ class IntensityMinutes(Base, InsertBase):
     value = Column(Float)
 
 
+class BodyComposition(Base, InsertBase):
+    """
+    Scale weigh-ins from a connected smart scale (e.g. Index S2) or manual entry.
+
+    One row per weigh-in keyed by ``(user_id, timestamp)``. A user may weigh more than
+    once per day. Weight and bone/muscle mass are stored in grams to match the Garmin
+    Connect API and the existing ``user_profile.weight`` convention.
+    """
+
+    __tablename__ = "body_composition"
+
+    user_id = Column(BigInteger, ForeignKey("user.user_id"), primary_key=True)
+    timestamp = Column(DateTime(timezone=True), primary_key=True)
+    weight = Column(Float)
+    bmi = Column(Float)
+    body_fat = Column(Float)
+    body_water = Column(Float)
+    bone_mass = Column(Float)
+    muscle_mass = Column(Float)
+    physique_rating = Column(Integer)
+    visceral_fat = Column(Integer)
+    metabolic_age = Column(Integer)
+    source_type = Column(String)
+
+
 class Floors(Base, InsertBase):
     """
     Timeseries floors data from Garmin devices.

--- a/garmin_health_data/models.py
+++ b/garmin_health_data/models.py
@@ -803,6 +803,7 @@ class BodyComposition(Base, InsertBase):
     visceral_fat = Column(Integer)
     metabolic_age = Column(Integer)
     source_type = Column(String)
+    sample_pk = Column(BigInteger)
 
 
 class Floors(Base, InsertBase):

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -2251,6 +2251,11 @@ class GarminProcessor(Processor):
         for entry in entries:
             ts_ms = entry.get("timestampGMT") or entry.get("date")
             if ts_ms is None:
+                click.secho(
+                    f"⚠️ Skipping body composition entry with no timestamp: "
+                    f"{entry}.",
+                    fg="yellow",
+                )
                 continue
             records.append(
                 BodyComposition(
@@ -2266,6 +2271,7 @@ class GarminProcessor(Processor):
                     visceral_fat=entry.get("visceralFat"),
                     metabolic_age=entry.get("metabolicAge"),
                     source_type=entry.get("sourceType"),
+                    sample_pk=entry.get("samplePk"),
                 )
             )
 

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -36,6 +36,7 @@ from garmin_health_data.models import (
     ActivitySplitMetric,
     ActivityTsMetric,
     BodyBattery,
+    BodyComposition,
     BreathingDisruption,
     CyclingAggMetrics,
     Floors,
@@ -118,6 +119,7 @@ class GarminProcessor(Processor):
                 ("USER_PROFILE", self._process_user_profile),
                 ("ACTIVITIES_LIST", self._process_activities),
                 ("EXERCISE_SETS", self._process_exercise_sets),
+                ("BODY_COMPOSITION", self._process_body_composition),
                 ("FLOORS", self._process_floors),
                 ("HEART_RATE", self._process_heart_rate),
                 ("INTENSITY_MINUTES", self._process_intensity_minutes),
@@ -2230,6 +2232,53 @@ class GarminProcessor(Processor):
             )
         else:
             click.secho("⚠️ No aggregated intensity minutes data found.", fg="yellow")
+
+    def _process_body_composition(self, file_path: Path, session: Session):
+        """
+        Process a BODY_COMPOSITION file containing scale weigh-ins.
+
+        Extracts each entry from ``dateWeightList`` and inserts it into the
+        ``body_composition`` table keyed by ``(user_id, timestamp)`` with insert-only
+        semantics. Days with no weigh-in (empty list) are a no-op.
+
+        :param file_path: Path to the BODY_COMPOSITION JSON file.
+        :param session: SQLAlchemy Session object.
+        """
+        payload = self._load_json_file(file_path)
+
+        entries = payload.get("dateWeightList") or []
+        records = []
+        for entry in entries:
+            ts_ms = entry.get("timestampGMT") or entry.get("date")
+            if ts_ms is None:
+                continue
+            records.append(
+                BodyComposition(
+                    user_id=int(self.user_id),
+                    timestamp=datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc),
+                    weight=entry.get("weight"),
+                    bmi=entry.get("bmi"),
+                    body_fat=entry.get("bodyFat"),
+                    body_water=entry.get("bodyWater"),
+                    bone_mass=entry.get("boneMass"),
+                    muscle_mass=entry.get("muscleMass"),
+                    physique_rating=entry.get("physiqueRating"),
+                    visceral_fat=entry.get("visceralFat"),
+                    metabolic_age=entry.get("metabolicAge"),
+                    source_type=entry.get("sourceType"),
+                )
+            )
+
+        if records:
+            upsert_model_instances(
+                session=session,
+                model_instances=records,
+                conflict_columns=["user_id", "timestamp"],
+                on_conflict_update=False,
+            )
+            click.echo(f"Processed {len(records)} body composition records.")
+        else:
+            click.secho("⚠️ No body composition data found.", fg="yellow")
 
     def _process_floors(self, file_path: Path, session: Session):
         """

--- a/garmin_health_data/tables.ddl
+++ b/garmin_health_data/tables.ddl
@@ -552,6 +552,28 @@ CREATE TABLE IF NOT EXISTS intensity_minutes (
 CREATE INDEX IF NOT EXISTS intensity_minutes_user_id_timestamp_idx
 ON intensity_minutes (user_id, timestamp DESC);
 
+-- Scale weigh-ins from a connected smart scale (e.g. Index S2) or manual entry. One row per measurement keyed by (user_id, timestamp); a user may weigh more than once per day.
+CREATE TABLE IF NOT EXISTS body_composition (
+    user_id BIGINT NOT NULL              -- References user(user_id). Identifies which user this weigh-in belongs to.
+    , timestamp DATETIME NOT NULL          -- UTC timestamp of the weigh-in (timestampGMT from the API).
+    , weight FLOAT                         -- Body weight in grams.
+    , bmi FLOAT                            -- Body Mass Index.
+    , body_fat FLOAT                       -- Body fat percentage (0-100).
+    , body_water FLOAT                     -- Body water percentage (0-100).
+    , bone_mass FLOAT                      -- Bone mass in grams.
+    , muscle_mass FLOAT                    -- Muscle mass in grams.
+    , physique_rating INTEGER              -- Garmin physique rating (1-9).
+    , visceral_fat INTEGER                 -- Visceral fat rating.
+    , metabolic_age INTEGER                -- Metabolic age in years.
+    , source_type TEXT                     -- Origin of the measurement (e.g., ''INDEX_SCALE'', ''MANUAL'').
+    , create_ts DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP  -- Timestamp when the record was created in the database.
+    , PRIMARY KEY (user_id, timestamp)
+    , FOREIGN KEY (user_id) REFERENCES user (user_id)
+);
+
+CREATE INDEX IF NOT EXISTS body_composition_user_id_timestamp_idx
+ON body_composition (user_id, timestamp DESC);
+
 -- Floors climbed measurements from Garmin devices tracking floors ascended and descended throughout the day at 15-minute intervals. Records are available only when floor climbing activity is detected.
 CREATE TABLE IF NOT EXISTS floors (
     user_id BIGINT NOT NULL              -- References user(user_id). Identifies which user this floors measurement belongs to.

--- a/garmin_health_data/tables.ddl
+++ b/garmin_health_data/tables.ddl
@@ -566,6 +566,7 @@ CREATE TABLE IF NOT EXISTS body_composition (
     , visceral_fat INTEGER                 -- Visceral fat rating.
     , metabolic_age INTEGER                -- Metabolic age in years.
     , source_type TEXT                     -- Origin of the measurement (e.g., ''INDEX_SCALE'', ''MANUAL'').
+    , sample_pk BIGINT                     -- Garmin's stable per-sample ID (samplePk). Nullable for manual entries lacking the field. Use to reconcile deletions made in Garmin Connect.
     , create_ts DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP  -- Timestamp when the record was created in the database.
     , PRIMARY KEY (user_id, timestamp)
     , FOREIGN KEY (user_id) REFERENCES user (user_id)
@@ -573,6 +574,9 @@ CREATE TABLE IF NOT EXISTS body_composition (
 
 CREATE INDEX IF NOT EXISTS body_composition_user_id_timestamp_idx
 ON body_composition (user_id, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS body_composition_sample_pk_idx
+ON body_composition (sample_pk);
 
 -- Floors climbed measurements from Garmin devices tracking floors ascended and descended throughout the day at 15-minute intervals. Records are available only when floor climbing activity is detected.
 CREATE TABLE IF NOT EXISTS floors (

--- a/tests/test_garmin_client_api.py
+++ b/tests/test_garmin_client_api.py
@@ -1,0 +1,114 @@
+"""
+Tests for thin API wrappers in :mod:`garmin_health_data.garmin_client.api`.
+
+Covers normalization of endpoint-specific empty-response shapes that the extractor's
+generic ``if data:`` truthiness check would otherwise misclassify as non-empty.
+"""
+
+from unittest.mock import MagicMock
+
+from garmin_health_data.garmin_client import api
+
+
+class TestGetBodyComposition:
+    """
+    Tests for :func:`api.get_body_composition` empty-response normalization.
+
+    The Garmin weight endpoint returns a populated wrapper dict on no-data days
+    (``{startDate, endDate, dateWeightList: [], totalAverage: {...nulls...}}``). Without
+    normalization the extractor would write one useless JSON file per day for users
+    without scale data, since a non-empty dict is truthy. ``get_body_composition`` must
+    collapse that shape to ``None`` so the extractor short-circuits.
+    """
+
+    def test_returns_payload_when_weighins_present(self) -> None:
+        """
+        A populated ``dateWeightList`` must be returned verbatim so the extractor saves
+        the file and the processor can map fields downstream.
+        """
+        payload = {
+            "startDate": "2026-04-15",
+            "endDate": "2026-04-15",
+            "dateWeightList": [
+                {
+                    "timestampGMT": 1713182400000,
+                    "weight": 75300.0,
+                    "bmi": 24.5,
+                    "sourceType": "INDEX_SCALE",
+                }
+            ],
+            "totalAverage": {"weight": 75300.0},
+        }
+        client = MagicMock()
+        client._connectapi.return_value = payload
+
+        result = api.get_body_composition(client, "2026-04-15")
+
+        assert result is payload
+        client._connectapi.assert_called_once_with(
+            api.WEIGHT_DATERANGE_URL,
+            params={"startDate": "2026-04-15", "endDate": "2026-04-15"},
+        )
+
+    def test_returns_none_when_date_weight_list_empty(self) -> None:
+        """
+        On no-data days the API returns the wrapper dict with an empty
+        ``dateWeightList``.
+
+        ``get_body_composition`` must collapse that to ``None`` so the extractor's
+        truthiness check skips the file write.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = {
+            "startDate": "2026-04-15",
+            "endDate": "2026-04-15",
+            "dateWeightList": [],
+            "totalAverage": {"weight": None, "bmi": None},
+        }
+
+        result = api.get_body_composition(client, "2026-04-15")
+
+        assert result is None
+
+    def test_returns_none_when_date_weight_list_missing(self) -> None:
+        """
+        Defensive: if the endpoint ever omits ``dateWeightList`` entirely, treat that as
+        no data rather than letting a wrapper-only dict through.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = {
+            "startDate": "2026-04-15",
+            "endDate": "2026-04-15",
+        }
+
+        result = api.get_body_composition(client, "2026-04-15")
+
+        assert result is None
+
+    def test_returns_none_when_response_is_none(self) -> None:
+        """
+        If ``_connectapi`` returns ``None`` (e.g. transient empty body), pass that
+        through as ``None`` rather than raising.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = None
+
+        result = api.get_body_composition(client, "2026-04-15")
+
+        assert result is None
+
+    def test_default_enddate_matches_startdate(self) -> None:
+        """
+        When ``enddate`` is omitted, ``startdate`` is used for both bounds (single-day
+        query), matching the day-by-day extraction loop in
+        :meth:`GarminExtractor._extract_day_by_day`.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = {"dateWeightList": []}
+
+        api.get_body_composition(client, "2026-04-15")
+
+        client._connectapi.assert_called_once_with(
+            api.WEIGHT_DATERANGE_URL,
+            params={"startDate": "2026-04-15", "endDate": "2026-04-15"},
+        )

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1637,12 +1637,14 @@ class TestProcessBodyComposition:
         assert first.visceral_fat == 8
         assert first.metabolic_age == 30
         assert first.source_type == "INDEX_SCALE"
+        assert first.sample_pk == 1714564800000
 
         second = records[1]
         assert second.weight == 75100.0
         assert second.source_type == "MANUAL"
         assert second.bmi is None
         assert second.body_fat is None
+        assert second.sample_pk is None
 
     @patch("garmin_health_data.processor.upsert_model_instances")
     def test_empty_date_weight_list_is_noop(
@@ -1661,14 +1663,20 @@ class TestProcessBodyComposition:
 
         mock_upsert.assert_not_called()
 
+    @patch("garmin_health_data.processor.click.secho")
     @patch("garmin_health_data.processor.upsert_model_instances")
     def test_falls_back_to_date_when_timestamp_gmt_missing(
-        self, mock_upsert, processor, mock_session, tmp_path
+        self,
+        mock_upsert,
+        mock_secho,
+        processor,
+        mock_session,
+        tmp_path,
     ):
         """
         Some payloads omit ``timestampGMT``; ``date`` is the fallback.
 
-        Entries with neither are skipped without raising.
+        Entries with neither are skipped with a yellow warning.
         """
         data = {
             "dateWeightList": [
@@ -1689,6 +1697,13 @@ class TestProcessBodyComposition:
         assert records[0].timestamp == datetime(
             2024, 5, 1, 12, 0, 0, tzinfo=timezone.utc
         )
+
+        # Verify a yellow warning surfaced for the entry with no timestamp.
+        warnings = [
+            call for call in mock_secho.call_args_list if "no timestamp" in call.args[0]
+        ]
+        assert len(warnings) == 1
+        assert warnings[0].kwargs.get("fg") == "yellow"
 
     def test_persists_to_real_database(self, db_session: Session, tmp_path):
         """

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -22,6 +22,7 @@ from garmin_health_data.models import (
     ActivityPath,
     ActivitySplitMetric,
     ActivityTsMetric,
+    BodyComposition,
     SleepLevel,
     StrengthExercise,
     StrengthSet,
@@ -1556,3 +1557,220 @@ class TestProcessFitSubSecond:
         # Coalesced to one row; last value wins.
         assert len(rows) == 1
         assert rows[0].value == 152.0
+
+
+# --- Body composition tests -------------------------------------------------
+
+
+class TestProcessBodyComposition:
+    """
+    Tests for _process_body_composition method.
+    """
+
+    @patch("garmin_health_data.processor.upsert_model_instances")
+    def test_inserts_records_with_field_mapping(
+        self, mock_upsert, processor, mock_session, tmp_path
+    ):
+        """
+        Verify each ``dateWeightList`` entry is mapped to a BodyComposition record with
+        insert-or-ignore semantics on (user_id, timestamp).
+        """
+        # Arrange: one fully-populated INDEX_SCALE entry plus one partial MANUAL
+        # entry to confirm null fields propagate through .get().
+        # Timestamps: 1714564800000 ms = 2024-05-01 12:00 UTC,
+        #             1714651200000 ms = 2024-05-02 12:00 UTC.
+        data = {
+            "startDate": "2024-05-01",
+            "endDate": "2024-05-01",
+            "dateWeightList": [
+                {
+                    "samplePk": 1714564800000,
+                    "date": 1714564800000,
+                    "calendarDate": "2024-05-01",
+                    "timestampGMT": 1714564800000,
+                    "weight": 75300.0,
+                    "bmi": 24.5,
+                    "bodyFat": 22.5,
+                    "bodyWater": 55.2,
+                    "boneMass": 3500.0,
+                    "muscleMass": 60000.0,
+                    "physiqueRating": 5,
+                    "visceralFat": 8,
+                    "metabolicAge": 30,
+                    "sourceType": "INDEX_SCALE",
+                },
+                {
+                    "timestampGMT": 1714651200000,
+                    "weight": 75100.0,
+                    "sourceType": "MANUAL",
+                },
+            ],
+        }
+        file_path = tmp_path / "123_BODY_COMPOSITION_2025-05-01T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        # Act.
+        processor._process_body_composition(file_path, mock_session)
+
+        # Assert: upsert called once with insert-or-ignore semantics.
+        mock_upsert.assert_called_once()
+        kwargs = mock_upsert.call_args.kwargs
+        assert kwargs["session"] == mock_session
+        assert kwargs["conflict_columns"] == ["user_id", "timestamp"]
+        assert kwargs["on_conflict_update"] is False
+
+        records = kwargs["model_instances"]
+        assert len(records) == 2
+        assert all(isinstance(r, BodyComposition) for r in records)
+
+        first = records[0]
+        assert first.user_id == 123456789
+        assert first.timestamp == datetime(2024, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+        assert first.weight == 75300.0
+        assert first.bmi == 24.5
+        assert first.body_fat == 22.5
+        assert first.body_water == 55.2
+        assert first.bone_mass == 3500.0
+        assert first.muscle_mass == 60000.0
+        assert first.physique_rating == 5
+        assert first.visceral_fat == 8
+        assert first.metabolic_age == 30
+        assert first.source_type == "INDEX_SCALE"
+
+        second = records[1]
+        assert second.weight == 75100.0
+        assert second.source_type == "MANUAL"
+        assert second.bmi is None
+        assert second.body_fat is None
+
+    @patch("garmin_health_data.processor.upsert_model_instances")
+    def test_empty_date_weight_list_is_noop(
+        self, mock_upsert, processor, mock_session, tmp_path
+    ):
+        """
+        Days with no weigh-in return an empty ``dateWeightList`` and must not call
+        upsert.
+        """
+        data = {"dateWeightList": [], "totalAverage": {}}
+        file_path = tmp_path / "123_BODY_COMPOSITION_2025-05-01T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        processor._process_body_composition(file_path, mock_session)
+
+        mock_upsert.assert_not_called()
+
+    @patch("garmin_health_data.processor.upsert_model_instances")
+    def test_falls_back_to_date_when_timestamp_gmt_missing(
+        self, mock_upsert, processor, mock_session, tmp_path
+    ):
+        """
+        Some payloads omit ``timestampGMT``; ``date`` is the fallback.
+
+        Entries with neither are skipped without raising.
+        """
+        data = {
+            "dateWeightList": [
+                {"date": 1714564800000, "weight": 75000.0},
+                {"weight": 76000.0},  # No timestamp at all -- skipped.
+            ],
+        }
+        file_path = tmp_path / "123_BODY_COMPOSITION_2025-05-01T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        processor._process_body_composition(file_path, mock_session)
+
+        mock_upsert.assert_called_once()
+        records = mock_upsert.call_args.kwargs["model_instances"]
+        assert len(records) == 1
+        assert records[0].weight == 75000.0
+        assert records[0].timestamp == datetime(
+            2024, 5, 1, 12, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_persists_to_real_database(self, db_session: Session, tmp_path):
+        """
+        End-to-end: write a real JSON file, run the processor against an in-memory
+        SQLite DB, and verify the rows landed with correct field mapping.
+        """
+        # Arrange: seed user (FK target).
+        upsert_model_instances(
+            session=db_session,
+            model_instances=[User(user_id=999, full_name="Test")],
+            conflict_columns=["user_id"],
+            on_conflict_update=True,
+        )
+        db_session.commit()
+
+        data = {
+            "dateWeightList": [
+                {
+                    "timestampGMT": 1714564800000,
+                    "weight": 75300.0,
+                    "bmi": 24.5,
+                    "bodyFat": 22.5,
+                    "boneMass": 3500.0,
+                    "muscleMass": 60000.0,
+                    "sourceType": "INDEX_SCALE",
+                }
+            ],
+        }
+        file_path = tmp_path / "999_BODY_COMPOSITION_2025-05-01T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        proc = GarminProcessor(FileSet(file_paths=[], files={}), MagicMock())
+        proc.user_id = 999
+
+        # Act.
+        proc._process_body_composition(file_path, db_session)
+        db_session.commit()
+
+        # Assert.
+        rows = db_session.execute(select(BodyComposition)).scalars().all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.user_id == 999
+        # SQLite drops tzinfo on DateTime(timezone=True) round-trip; compare naive.
+        assert row.timestamp.replace(tzinfo=timezone.utc) == datetime(
+            2024, 5, 1, 12, 0, 0, tzinfo=timezone.utc
+        )
+        assert row.weight == 75300.0
+        assert row.body_fat == 22.5
+        assert row.muscle_mass == 60000.0
+        assert row.source_type == "INDEX_SCALE"
+
+    def test_reprocess_is_idempotent(self, db_session: Session, tmp_path):
+        """
+        Re-running the processor on the same payload must not duplicate or modify
+        rows -- ON CONFLICT DO NOTHING semantics.
+        """
+        upsert_model_instances(
+            session=db_session,
+            model_instances=[User(user_id=999, full_name="Test")],
+            conflict_columns=["user_id"],
+            on_conflict_update=True,
+        )
+        db_session.commit()
+
+        data = {
+            "dateWeightList": [
+                {"timestampGMT": 1714564800000, "weight": 75300.0},
+            ],
+        }
+        file_path = tmp_path / "999_BODY_COMPOSITION_2025-05-01T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        proc = GarminProcessor(FileSet(file_paths=[], files={}), MagicMock())
+        proc.user_id = 999
+
+        proc._process_body_composition(file_path, db_session)
+        db_session.commit()
+        proc._process_body_composition(file_path, db_session)
+        db_session.commit()
+
+        rows = db_session.execute(select(BodyComposition)).scalars().all()
+        assert len(rows) == 1


### PR DESCRIPTION
## Summary
- Adds a new `BODY_COMPOSITION` data type that fetches scale weigh-ins from `/weight-service/weight/daterangesnapshot` (range-API, parallel to `ACTIVITIES_LIST`).
- Persists each weigh-in as one row in a new `body_composition` table keyed by `(user_id, timestamp)` — preserves multiple weigh-ins per day.
- Captures weight, BMI, body fat %, body water %, bone mass, muscle mass, physique rating, visceral fat, metabolic age, and `source_type` (e.g. `INDEX_SCALE`, `MANUAL`). Weight / bone / muscle mass stored in grams to match the existing `user_profile.weight` convention.
- Processor uses `INSERT … ON CONFLICT DO NOTHING` (measurements are immutable) with a `timestampGMT` → `date` fallback and an empty-list no-op. Schema added to both `tables.ddl` and the matching `BodyComposition` ORM model.

## Test plan
- [x] New unit tests covering field mapping, empty `dateWeightList`, timestamp fallback, end-to-end persistence to a real SQLite DB, and re-processing idempotency (5 tests, all passing).
- [x] `make check-format` equivalent — `black --check` and `sqlfluff lint` clean on touched files.
- [ ] Manual end-to-end run against a real account with a connected Index scale (reviewer to verify on their side if desired).

## Notes
Per `CLAUDE.md`, schema/processor changes are normally synced from openetl first. Happy to mirror this to the openetl Garmin pipeline if you'd like — flag and I'll open the matching PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)