### PR TITLE
release: 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-05-02
+
+### Added
+
+- **`BODY_COMPOSITION` data type**: scale weigh-ins from a connected smart scale (e.g. Index S2) or manual weight entries. Captures weight, BMI, body fat %, body water %, bone mass, muscle mass, physique rating, visceral fat, metabolic age, and `source_type` (e.g. `INDEX_SCALE`, `MANUAL`). Persisted to a new `body_composition` table keyed by `(user_id, timestamp)` so multiple weigh-ins per day are preserved; weight and bone/muscle mass stored in grams to match the existing `user_profile.weight` convention. Insert-only with `ON CONFLICT DO NOTHING` (measurements are immutable). Contributed by @amanusk in #49.
+- **`sample_pk` column on `body_composition`**: nullable `BIGINT` capturing Garmin's stable per-sample identifier (`samplePk` from the API), with a non-unique index. Provides a stable handle for reconciling rows against deletions made in Garmin Connect (e.g. user removes a bad weigh-in). Nullable because manual entries lack the field.
+
+### Fixed
+
+- **`get_body_composition` saved one useless JSON file per day for users with no scale data**. The Garmin `/weight-service/weight/daterangesnapshot` endpoint returns a populated wrapper dict on no-data days (`startDate`, `endDate`, an empty `dateWeightList`, and a `totalAverage` of nulls) rather than an empty response. The extractor's generic `if data:` truthiness check saw the wrapper as truthy and wrote a file. The API client now collapses the empty-wrapper shape to `None` so the extractor short-circuits, matching the contract of other RANGE-typed endpoints (e.g. `ACTIVITIES_LIST`).
+
+### Changed
+
+- **`_process_body_composition` now warns when an entry has neither `timestampGMT` nor `date`**: previously such entries were silently skipped. A yellow `⚠️ Skipping body composition entry with no timestamp` warning matches the convention in `_process_training_readiness` / `_process_floors` and surfaces silent data loss in the run log.
+- **API module docstring** (`garmin_client/api.py`): bumped endpoint count from 15 to 16 and renamed the "Range activities" bucket to "Range data" to accurately describe both activity-related and wellness range endpoints.
+- **README**: added `BODY_COMPOSITION` to the data types table and the Health Time-Series table-structure section (now 8 tables); bumped the total table count from 33 to 34 across the schema overview, project pitch, and comparison matrix.
+
 ## [2.7.4] - 2026-04-30
 
 ### Fixed

--- a/garmin_health_data/__version__.py
+++ b/garmin_health_data/__version__.py
@@ -2,4 +2,4 @@
 Version information for garmin-health-data.
 """
 
-__version__ = "2.7.4"
+__version__ = "2.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garmin-health-data"
-version = "2.7.4"
+version = "2.8.0"
 description = "Extract your Garmin Connect health data to a local SQLite database"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Release 2.8.0. Bumps version in `__version__.py` and `pyproject.toml`, adds the changelog entry covering #49.

## Highlights since 2.7.4

### Added
- New `BODY_COMPOSITION` data type with the `body_composition` table (12 columns + `sample_pk`), per-weigh-in granularity, and full unit-test coverage. Live-tested against a real account at 700-day backfill (383 rows, 100% sample_pk populated). Contributed by @amanusk in #49.

### Fixed
- `get_body_composition` no longer writes useless JSON files for accounts with no scale data; the Garmin endpoint's empty-wrapper shape is collapsed to `None` so the extractor short-circuits.

### Changed
- Body composition processor now warns instead of silently skipping entries with no timestamp.
- API module docstring + README updated for the new data type.

See `CHANGELOG.md` for details.

## Test plan

- [x] Full pytest suite green (192 passed, 1 skipped) on the release branch.
- [x] `make check-format` clean (black, autoflake, docformatter, sqlfluff).
- [x] Live verification: fresh-DB schema applies cleanly with `sample_pk` column + index; end-to-end persistence test confirms `INDEX_SCALE` / `MANUAL` / no-timestamp paths all behave correctly.
- [x] amanusk's own 700-day backfill against a real account: 383 rows, 0 quarantines, 100% sample_pk populated.