### PR TITLE
chore(release): bump pyproject.toml to 2.9.1 (missed in #58)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garmin-health-data"
-version = "2.9.0"
+version = "2.9.1"
 description = "Extract your Garmin Connect health data to a local SQLite database"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Fixes the v2.9.1 PyPI publish that failed because `pyproject.toml` still said `2.9.0`. PR #58 only bumped `garmin_health_data/__version__.py`. The build reads from `pyproject.toml`'s `[project].version`, so it produced `garmin_health_data-2.9.0-py3-none-any.whl` and PyPI rejected the upload as a duplicate.

The v2.9.1 git tag and GitHub release page have been deleted. Once this PR merges I'll recreate the v2.9.1 tag + release on the new HEAD, which will re-trigger the publish workflow.

Future-proofing follow-up worth considering (NOT in this PR): make `pyproject.toml` use `dynamic = ["version"]` reading from `__version__.py` so this drift can't happen again.

## Test plan

- [ ] CI green (no code change, just a metadata bump).