### PR TITLE
feat(menstrual): menstrual cycle day and summary extraction (2.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0] - 2026-05-26
+
+### Added
+
+- **Menstrual cycle data extraction** ([#61](https://github.com/diegoscarabelli/garmin-health-data/issues/61), [#64](https://github.com/diegoscarabelli/garmin-health-data/pull/64)): two new Garmin Connect data types backed by the `periodic-health` service. `MENSTRUAL_CYCLE_DAY` (DAILY) extracts the per-day cycle state from the `dayview` endpoint: phase (MENSTRUAL / FOLLICULAR / OVULATORY / LUTEAL), day-in-cycle, period length, predicted cycle length, plus the user's symptoms / moods / discharge tags, flow, sex drive, sexual activity, freeform notes, ovulation and baby-movement flags. `MENSTRUAL_CYCLE_SUMMARY` (RANGE) extracts per-cycle summaries from the `calendar` endpoint, covering both user-logged cycles and Garmin's projections of upcoming cycles; the API wrapper paginates >92-day ranges into the endpoint's max chunk size and merges results, deduping by `startDate`. Rows persist for any day inside an observed or predicted cycle window; days the user has not logged within a predicted window get `daySummary` filled in and `dayLog` columns NULL.
+- **Three new schema tables (total 35 → 38)**: `menstrual_cycle_day` (one row per day inside any observed or predicted cycle window, UPSERT by `(user_id, date)`); `menstrual_cycle_tag` (polymorphic tag table for symptoms / moods / discharge with a composite `(user_id, date)` cascade FK to `menstrual_cycle_day`; processor uses delete-then-reinsert per day so user-removed tags propagate); `menstrual_cycle_summary` (one row per cycle, observed rows UPSERT by `(user_id, start_date)`, predicted rows wipe-and-replace on every extract because Garmin recomputes projection dates as new data is logged). Cycle length is intentionally not stored; derive in SQL via `LEAD(start_date) OVER (PARTITION BY user_id ORDER BY start_date) - start_date`.
+- **`MenstrualCyclePhase` IntEnum** mirroring the `SleepStage` precedent (1=MENSTRUAL, 2=FOLLICULAR, 3=OVULATORY, 4=LUTEAL): the raw integer index from `daySummary.currentPhase` is denormalized to the text label and stored in `menstrual_cycle_day.current_phase`; the integer is not persisted.
+
+### Changed
+
+- **Duplicate prevention is now a four-tier approach** (was three-tier). The new fourth tier documents the wipe-and-replace policy for predicted menstrual cycle summary rows: Garmin's projected start dates drift between runs, so the `(user_id, start_date)` PK no longer matches the latest projection on each extract; a pure UPSERT would accumulate stale predicted rows. The processor `DELETE`s all `predicted_cycle = TRUE` rows for the user before inserting the new set; observed cycles continue to UPSERT and survive untouched.
+
+### Fixed
+
+- **Test pollution: `tests/test_auth_extended.py` created an empty `~/.garminconnect/12345678/` directory on every CI run** ([#64](https://github.com/diegoscarabelli/garmin-health-data/pull/64)). The four `TestRefreshTokens` cases called `refresh_tokens()` without overriding the default `base_token_dir="~/.garminconnect"`. Because `get_user_profile` was mocked to return `{"id": "12345678"}`, the real auth code's `Path.mkdir` ran against `~/.garminconnect`. `garmin.dump()` was a MagicMock so no token file was written, but the empty directory was then discovered as a candidate account by subsequent `garmin extract` runs and surfaced as a phantom user. Tests now pass `base_token_dir=str(tmp_path)`.
+- **Wrapper returning `None` for empty calendar responses made the wipe-and-replace path unreachable** ([#64](https://github.com/diegoscarabelli/garmin-health-data/pull/64)). The original `get_menstrual_calendar_data` returned `None` whenever the API responded with no cycles. Because the extractor guards file writes with `if data:`, no file landed and the processor never ran, so stale `predicted_cycle = TRUE` rows from earlier extracts could not be wiped if the user later stopped tracking cycles or queried a window with no cycles. Fix distinguishes "transport failure on every chunk" (still returns `None`) from "HTTP success with `cycleSummaries: []`" (returns the merged shape with empty arrays so the file lands and the wipe fires).
+
 ## [2.10.0] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/user-attachments/assets/65023665-fa7a-4bbf-85d6-c3d4a3145171
 
 ## Features
 
-- 🏥 **Comprehensive data**: a single `garmin extract` command downloads sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics, and activity files in FIT or TCX format (time-series, laps, splits) as local files and loads them into a SQLite database in one pass.
+- 🏥 **Comprehensive data**: a single `garmin extract` command downloads sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics, menstrual cycle, and activity files in FIT or TCX format (time-series, laps, splits) as local files and loads them into a SQLite database in one pass.
 - 👥 **Multi-account**: one database across multiple Garmin Connect accounts (e.g. family members). Run `garmin auth` once per account; extraction discovers and processes them automatically.
 - 🛡️ **Resilient pipeline**: four-folder lifecycle (`ingest/process/storage/quarantine`), auto-resume from the last update, crash recovery, and per-date / per-data-type / per-activity / per-FileSet failure isolation. Original files are preserved on disk for offline backup and post-mortem inspection.
 - 🗜️ **Bounded disk usage**: `garmin downsample` aggregates per-second sensor data into time-bucketed records, and `garmin prune` deletes the source rows. Together they let you run a multi-year history without unbounded growth (`activity_ts_metric` is ~93% of typical DB size).
@@ -383,11 +383,12 @@ If all five strategies are exhausted without success (uncommon — typically onl
 <details>
 <summary><strong>Duplicate prevention &amp; reprocessing</strong></summary>
 
-Duplicates are prevented through a three-tier approach:
+Duplicates are prevented through a four-tier approach:
 
-1. **Activity metrics from FIT or TCX files** (time-series, laps, splits): delete+insert pattern. Existing rows are deleted and fresh data re-inserted in the same transaction, handling added/removed laps or records between reprocesses. The `ts_data_available` flag tracks whether time-series data exists. TCX is parsed for activities uploaded to Garmin Connect from older devices or third-party apps; splits are FIT-only (TCX has no split concept).
+1. **Activity metrics from FIT or TCX files** (time-series, laps, splits) **and per-day menstrual cycle tags** (symptoms, moods, discharge): delete+insert pattern. Existing rows are deleted and fresh data re-inserted in the same transaction. For activity metrics this handles added/removed laps or records between reprocesses; the `ts_data_available` flag tracks whether time-series data exists. For menstrual cycle tags, it ensures user-removed symptoms/moods on Garmin Connect propagate to the local DB on the next extract. TCX is parsed for activities uploaded to Garmin Connect from older devices or third-party apps; splits are FIT-only (TCX has no split concept).
 2. **JSON wellness time-series** (heart rate, sleep movement, stress, body battery, etc.): `INSERT...ON CONFLICT DO NOTHING` for idempotent upserts.
-3. **Main records** (activities, sleep, user profile): `INSERT...ON CONFLICT DO UPDATE` to refresh existing records with new data.
+3. **Main records** (activities, sleep, user profile, menstrual cycle day, observed menstrual cycle summaries): `INSERT...ON CONFLICT DO UPDATE` to refresh existing records with new data.
+4. **Predicted menstrual cycle summaries** (`menstrual_cycle_summary` rows with `predicted_cycle = TRUE`): wipe-and-replace per extract. Garmin recomputes its projected start dates as new data is logged, so a pure upsert would accumulate stale predicted rows whose `start_date` PK no longer matches the latest projection. The processor `DELETE`s all predicted rows for the user before inserting the new set; observed (logged) cycles use pattern 3 and survive untouched.
 
 This means you can safely:
 

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ The command is **idempotent** (skips tables that already have cascade), runs a p
 | **STEPS** | Step counts and activity levels | 15-min intervals |
 | **FLOORS** | Floors climbed and descended | 15-min intervals |
 | **INTENSITY_MINUTES** | Moderate/vigorous activity minutes | 15-min intervals |
-| **MENSTRUAL_CYCLE_DAY** | Per-day cycle log: phase, day-in-cycle, period length, symptoms / moods / discharge tags, flow, sex drive, sexual activity, notes, ovulation flag | Per logged day |
+| **MENSTRUAL_CYCLE_DAY** | Per-day cycle state: phase, day-in-cycle, period length, plus the user's symptoms / moods / discharge tags, flow, sex drive, sexual activity, notes, ovulation flag on logged days | Per day inside any observed or predicted cycle window |
 | **MENSTRUAL_CYCLE_SUMMARY** | Per-cycle summaries (observed + predicted): start date, period length | Per cycle |
 | **BODY_COMPOSITION** | Scale weigh-ins: weight, BMI, body fat %, body water %, bone mass, muscle mass | Per weigh-in |
 | **ACTIVITIES_LIST** | Detailed activity summaries | Per activity |

--- a/README.md
+++ b/README.md
@@ -508,6 +508,8 @@ The command is **idempotent** (skips tables that already have cascade), runs a p
 | **STEPS** | Step counts and activity levels | 15-min intervals |
 | **FLOORS** | Floors climbed and descended | 15-min intervals |
 | **INTENSITY_MINUTES** | Moderate/vigorous activity minutes | 15-min intervals |
+| **MENSTRUAL_CYCLE_DAY** | Per-day cycle log: phase, day-in-cycle, period length, symptoms / moods / discharge tags, flow, sex drive, sexual activity, notes, ovulation flag | Per logged day |
+| **MENSTRUAL_CYCLE_SUMMARY** | Per-cycle summaries (observed + predicted): start date, period length | Per cycle |
 | **BODY_COMPOSITION** | Scale weigh-ins: weight, BMI, body fat %, body water %, bone mass, muscle mass | Per weigh-in |
 | **ACTIVITIES_LIST** | Detailed activity summaries | Per activity |
 | **EXERCISE_SETS** | Per-set strength training data: reps, weight, ML-classified exercise name | Per activity |
@@ -518,7 +520,7 @@ The command is **idempotent** (skips tables that already have cascade), runs a p
 
 ### Database Schema
 
-The SQLite database contains 35 tables organized by category. The complete schema is defined in [garmin_health_data/tables.ddl](garmin_health_data/tables.ddl) following the same pattern as the [openetl project](https://github.com/diegoscarabelli/openetl). The schema includes inline documentation comments for all tables and columns, which are preserved in the SQLite database itself:
+The SQLite database contains 38 tables organized by category. The complete schema is defined in [garmin_health_data/tables.ddl](garmin_health_data/tables.ddl) following the same pattern as the [openetl project](https://github.com/diegoscarabelli/openetl). The schema includes inline documentation comments for all tables and columns, which are preserved in the SQLite database itself:
 
 ```bash
 # View schema for a specific table
@@ -636,6 +638,16 @@ race_predictions (predicted race times)
 
 *Foreign keys: all tables → `user.user_id`. Note: `personal_record.activity_id` column exists but has no FK constraint (allows processing PRs before the linked activity is extracted).*
 
+**Cycle Tracking (3 tables)**
+
+```
+menstrual_cycle_day (daily cycle log: phase, day-in-cycle, flow, notes, ovulation flag)
+├── menstrual_cycle_tag (symptoms / moods / discharge tagged on a day)
+menstrual_cycle_summary (per-cycle summaries: start date, period length, predicted flag)
+```
+
+*Foreign keys: `menstrual_cycle_day` → `user.user_id`; `menstrual_cycle_tag` → `menstrual_cycle_day(user_id, date)` ON DELETE CASCADE; `menstrual_cycle_summary` → `user.user_id`. Per-cycle summaries from Garmin's calendar endpoint include both user-logged cycles and Garmin's projections of upcoming cycles (predicted_cycle column). Predicted rows are wiped and re-inserted on every extract because Garmin recomputes projections as new data is logged; observed rows are upserted by `(user_id, start_date)`.*
+
 </details>
 
 ## Privacy & Security
@@ -643,10 +655,11 @@ race_predictions (predicted race times)
 - **Your credentials never leave your machine**: they're only used to obtain OAuth tokens, stored locally in `~/.garminconnect/<user_id>/`. On Unix-like systems, token directories and files are locked to owner-only access (0o700 directories, 0o600 files); on Windows, standard user-profile permissions apply.
 - **All data stays on your machine**: no cloud services involved.
 - **No analytics or tracking**: this tool doesn't send any data anywhere except querying the Garmin Connect API directly.
+- **Sensitive cycle-tracking fields**: when `MENSTRUAL_CYCLE_DAY` is extracted, the per-day log includes the user's freeform `notes`, `sexual_activity`, and `sex_drive` fields alongside the cycle-state scalars. These are captured for completeness so the local database is a faithful mirror of what Garmin Connect stores. They never leave the machine, but they are more sensitive than HR or steps; reviewers of the `garmin_data.db` file should know they're there.
 
 ## Comparison With Other Tools
 
-**[garmin-health-data](https://github.com/diegoscarabelli/garmin-health-data)** is designed for comprehensive data extraction with a well-structured relational schema that supports both human-powered analytics and LLM-powered analysis via agents querying the locally created SQLite file. It extracts complete FIT file data with per-second activity metrics, 1-minute sleep intervals, and sport-specific tables for detailed analysis. The normalized 34-table schema with explicit SQL constraints ensures data integrity and makes it easy to understand relationships for complex queries, power zone analysis, running dynamics, and long-term trend studies.
+**[garmin-health-data](https://github.com/diegoscarabelli/garmin-health-data)** is designed for comprehensive data extraction with a well-structured relational schema that supports both human-powered analytics and LLM-powered analysis via agents querying the locally created SQLite file. It extracts complete FIT file data with per-second activity metrics, 1-minute sleep intervals, and sport-specific tables for detailed analysis. The normalized 38-table schema with explicit SQL constraints ensures data integrity and makes it easy to understand relationships for complex queries, power zone analysis, running dynamics, and long-term trend studies.
 
 **[garmy](https://github.com/bes-dev/garmy)** is optimized for programmatic access to the Garmin Connect API, particularly useful for AI assistant integration via its built-in MCP (Model Context Protocol) server. It enables real-time interaction with Claude Desktop or custom chatbots for quick daily insights and summaries. However, it's limited to API-provided metrics (daily aggregates only, no FIT file access), making deep analytics or granular time-series analysis impossible. Best suited for lightweight health monitoring apps that prioritize AI integration over comprehensive data collection.
 
@@ -665,7 +678,7 @@ Check out [OpenETL's Garmin pipeline](https://github.com/diegoscarabelli/openetl
 | **Sleep data granularity** | ✅ 7 tables, 1-min intervals | ⚠️ 2 tables, less granular | ⚠️ 1 table, daily aggregate | ❌ | ❌ |
 | **FIT file time-series data** | ✅ All metrics (EAV schema) | ⚠️ Limited (~10 core fields) | ❌ API-only (no FIT files) | ❌ | ❌ |
 | **Power meter & advanced metrics** | ✅ Full support | ❌ Not captured | ❌ API limitations | ❌ | ❌ |
-| **Database schema quality** | ✅ Normalized, 35 tables | ⚠️ ~31 tables, mixed normalization | ❌ Very simple | N/A | N/A |
+| **Database schema quality** | ✅ Normalized, 38 tables | ⚠️ ~31 tables, mixed normalization | ❌ Very simple | N/A | N/A |
 | **Duplicate prevention** | ✅ Explicit SQL ON CONFLICT | ⚠️ ORM merge (undocumented) | ✅ ORM merge + sync tracking | N/A | N/A |
 | **Auto-resume** | ✅ | ✅ | ✅ | ✅ | ❌ |
 | **Active maintenance** | ✅ | ✅ | ✅ | ✅ | ⚠️ Limited |

--- a/garmin_health_data/constants.py
+++ b/garmin_health_data/constants.py
@@ -180,7 +180,10 @@ class GarminDataRegistry:
                 "/periodichealth-service/menstrualcycle/calendar/{start}/{end}",
                 "Per-cycle summaries (observed and predicted): start date, period "
                 "length, predicted flag. Calendar endpoint has a 92-day max range "
-                "per request; the API wrapper paginates longer windows transparently.",
+                "per request, paginated transparently by the wrapper for direct "
+                "callers. Note: today's extractor invokes RANGE methods day-by-day "
+                "with startdate=enddate, so a multi-day extract makes one API call "
+                "and one wipe-and-replace processor cycle per day. Tracked in #62.",
                 "🩸",
             ),
             GarminDataType(

--- a/garmin_health_data/constants.py
+++ b/garmin_health_data/constants.py
@@ -152,6 +152,16 @@ class GarminDataRegistry:
                 "time-series data and goal tracking.",
                 "⚡",
             ),
+            GarminDataType(
+                "MENSTRUAL_CYCLE_DAY",
+                "get_menstrual_data_for_date",
+                APIMethodTimeParam.DAILY,
+                "/periodichealth-service/menstrualcycle/dayview/{date}",
+                "Daily menstrual cycle log: phase, day-in-cycle, period length, "
+                "logged symptoms/moods/discharge, flow, sex drive, sexual activity, "
+                "freeform notes, ovulation and baby-movement flags.",
+                "🩸",
+            ),
             # Range Data - Date range parameters: get_method(start_str, end_str)
             GarminDataType(
                 "BODY_COMPOSITION",
@@ -162,6 +172,16 @@ class GarminDataRegistry:
                 "muscle mass, physique rating, visceral fat, metabolic age. Multiple "
                 "entries per day if the user weighs more than once.",
                 "⚖️",
+            ),
+            GarminDataType(
+                "MENSTRUAL_CYCLE_SUMMARY",
+                "get_menstrual_calendar_data",
+                APIMethodTimeParam.RANGE,
+                "/periodichealth-service/menstrualcycle/calendar/{start}/{end}",
+                "Per-cycle summaries (observed and predicted): start date, period "
+                "length, predicted flag. Calendar endpoint has a 92-day max range "
+                "per request; the API wrapper paginates longer windows transparently.",
+                "🩸",
             ),
             GarminDataType(
                 "ACTIVITIES_LIST",
@@ -346,6 +366,22 @@ class SleepStage(IntEnum):
     LIGHT = 1
     REM = 2
     AWAKE = 3
+
+
+class MenstrualCyclePhase(IntEnum):
+    """
+    Discrete menstrual cycle phase classification used by Garmin Connect.
+
+    Values map to the integer codes found in the MENSTRUAL_CYCLE_DAY JSON response under
+    daySummary.currentPhase. The enum name (e.g. "MENSTRUAL") is stored in
+    menstrual_cycle_day.current_phase as a denormalized human-readable label; the
+    integer index is not persisted.
+    """
+
+    MENSTRUAL = 1
+    FOLLICULAR = 2
+    OVULATORY = 3
+    LUTEAL = 4
 
 
 PR_TYPE_LABELS = {

--- a/garmin_health_data/garmin_client/api.py
+++ b/garmin_health_data/garmin_client/api.py
@@ -316,13 +316,18 @@ def get_menstrual_calendar_data(
     deduped by ``startDate``; ``loggedSymptomDays`` / ``loggedOvulationDays`` /
     ``loggedNoteDays`` are merged into sorted unique lists.
 
-    Normalizes empty responses to ``None`` (no ``cycleSummaries`` across any chunk) so
-    the extractor's ``if data:`` truthiness check skips the file write.
+    Returns ``None`` only when no chunk produced a response (e.g. transport failure on
+    every chunk). A successful response with zero cycles still returns the merged shape
+    with empty arrays so the file lands and ``_process_menstrual_cycle_summary`` can
+    fire its wipe-and-replace policy for stale predicted rows. Without this, a user who
+    stopped tracking cycles (or never had any in the queried window) would leave
+    previously-extracted predicted rows stranded in the database.
 
     :param client: GarminClient instance.
     :param startdate: Range start (``YYYY-MM-DD``, inclusive).
     :param enddate: Range end (``YYYY-MM-DD``, inclusive). Defaults to ``startdate``.
-    :return: Merged calendar dictionary, or ``None`` when no cycles were found.
+    :return: Merged calendar dictionary (possibly with empty arrays), or ``None`` when
+        no chunk in the range produced a response.
     """
     startdate = _validate_date_format(startdate, "startdate")
     if enddate is None:
@@ -342,13 +347,15 @@ def get_menstrual_calendar_data(
     logged_symptom: set = set()
     logged_ovulation: set = set()
     logged_note: set = set()
+    got_response = False
 
     chunk_start = start
     while chunk_start <= end:
         chunk_end = min(chunk_start + chunk_step, end)
         url = f"{MENSTRUAL_CALENDAR_URL}/{chunk_start.isoformat()}/{chunk_end.isoformat()}"
         result = client._connectapi(url)
-        if result:
+        if result is not None:
+            got_response = True
             for cycle in result.get("cycleSummaries") or []:
                 cycle_start = cycle.get("startDate")
                 if cycle_start:
@@ -358,7 +365,7 @@ def get_menstrual_calendar_data(
             logged_note.update(result.get("loggedNoteDays") or [])
         chunk_start = chunk_end + timedelta(days=1)
 
-    if not cycles_by_start:
+    if not got_response:
         return None
 
     return {

--- a/garmin_health_data/garmin_client/api.py
+++ b/garmin_health_data/garmin_client/api.py
@@ -246,13 +246,15 @@ def get_menstrual_data_for_date(
     The dayview endpoint returns the per-day cycle state (phase, day-in-cycle, predicted
     cycle length) wrapped in ``daySummary`` plus the user's logged data (symptoms,
     moods, discharge, flow, sex drive, sexual activity, notes, ovulation/baby-movement
-    flags) wrapped in ``dayLog``. Either wrapper may be absent; in particular Garmin
-    returns a bare ``{}`` for unlogged days that fall outside any known or predicted
-    cycle.
+    flags) wrapped in ``dayLog``. Days inside a predicted-cycle window return
+    ``daySummary`` populated and ``dayLog: null``; days outside every cycle window
+    return a bare ``{}``.
 
-    Normalizes empty responses to ``None`` so the extractor's ``if data:`` truthiness
-    check skips the file write, matching the behavior of other DAILY-typed endpoints
-    that lack data on some dates.
+    Returns ``None`` when neither ``daySummary`` nor ``dayLog`` is present. The
+    extractor's ``if data:`` check already drops a bare ``{}`` (it's falsy), but this
+    wrapper additionally drops *truthy* response shapes that lack the expected keys
+    (e.g. an unexpected wrapper-only dict) so the extractor never persists meaningless
+    payloads to disk.
 
     :param client: GarminClient instance.
     :param cdate: Date in ``YYYY-MM-DD`` format.

--- a/garmin_health_data/garmin_client/api.py
+++ b/garmin_health_data/garmin_client/api.py
@@ -1,7 +1,7 @@
 """
 API method implementations for the vendored Garmin Connect client.
 
-Each function here corresponds to one of the 16 Garmin Connect endpoints the
+Each function here corresponds to one of the Garmin Connect endpoints the
 openetl pipeline consumes. The functions are written as plain functions taking
 the ``GarminClient`` instance as their first argument so that the client class
 can stay slim, and so that the file is testable in isolation.
@@ -9,18 +9,19 @@ can stay slim, and so that the file is testable in isolation.
 Method-to-endpoint mapping is inherited from the upstream ``python-garminconnect``
 library; URL templates live in :mod:`.constants`.
 
-The 16 supported endpoints:
+The supported endpoints:
 
 - Daily wellness:        sleep, stress, respiration, heart_rates, training_readiness,
-                         training_status, steps, floors, intensity_minutes
+                         training_status, steps, floors, intensity_minutes,
+                         menstrual_cycle_dayview
 - Range data:            activities_by_date (paginated), activity_exercise_sets,
-                         body_composition
+                         body_composition, menstrual_cycle_calendar (paginated)
 - No-date metadata:      personal_records, race_predictions, user_profile
 - Binary download:       download_activity (FIT/TCX/GPX/KML/CSV)
 """
 
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -37,6 +38,9 @@ from .constants import (
     GPX_DOWNLOAD_URL,
     HEART_RATES_DAILY_URL,
     KML_DOWNLOAD_URL,
+    MENSTRUAL_CALENDAR_MAX_DAYS,
+    MENSTRUAL_CALENDAR_URL,
+    MENSTRUAL_DAYVIEW_URL,
     PERSONAL_RECORD_URL,
     RACE_PREDICTOR_URL,
     TCX_DOWNLOAD_URL,
@@ -233,6 +237,36 @@ def get_intensity_minutes_data(client: "GarminClient", cdate: str) -> Dict[str, 
     return client._connectapi(url)
 
 
+def get_menstrual_data_for_date(
+    client: "GarminClient", cdate: str
+) -> Optional[Dict[str, Any]]:
+    """
+    Fetch menstrual cycle dayview data for the given date.
+
+    The dayview endpoint returns the per-day cycle state (phase, day-in-cycle, predicted
+    cycle length) wrapped in ``daySummary`` plus the user's logged data (symptoms,
+    moods, discharge, flow, sex drive, sexual activity, notes, ovulation/baby-movement
+    flags) wrapped in ``dayLog``. Either wrapper may be absent; in particular Garmin
+    returns a bare ``{}`` for unlogged days that fall outside any known or predicted
+    cycle.
+
+    Normalizes empty responses to ``None`` so the extractor's ``if data:`` truthiness
+    check skips the file write, matching the behavior of other DAILY-typed endpoints
+    that lack data on some dates.
+
+    :param client: GarminClient instance.
+    :param cdate: Date in ``YYYY-MM-DD`` format.
+    :return: Menstrual cycle dictionary with ``daySummary`` and ``dayLog`` keys, or
+        ``None`` when no cycle data exists for the date.
+    """
+    cdate = _validate_date_format(cdate, "cdate")
+    url = f"{MENSTRUAL_DAYVIEW_URL}/{cdate}"
+    result = client._connectapi(url)
+    if result and (result.get("daySummary") or result.get("dayLog")):
+        return result
+    return None
+
+
 def get_body_composition(
     client: "GarminClient", startdate: str, enddate: Optional[str] = None
 ) -> Optional[Dict[str, Any]]:
@@ -265,6 +299,72 @@ def get_body_composition(
     if result and result.get("dateWeightList"):
         return result
     return None
+
+
+def get_menstrual_calendar_data(
+    client: "GarminClient", startdate: str, enddate: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """
+    Fetch menstrual cycle summaries (observed and predicted) for a date range.
+
+    The Garmin calendar endpoint enforces a hard ``MENSTRUAL_CALENDAR_MAX_DAYS``
+    (92-day) max range per request. This wrapper chunks longer ranges into contiguous
+    sub-windows, calls the endpoint once per chunk, and merges results. Duplicate
+    ``cycleSummaries`` entries (a single cycle may appear in adjacent chunks) are
+    deduped by ``startDate``; ``loggedSymptomDays`` / ``loggedOvulationDays`` /
+    ``loggedNoteDays`` are merged into sorted unique lists.
+
+    Normalizes empty responses to ``None`` (no ``cycleSummaries`` across any chunk) so
+    the extractor's ``if data:`` truthiness check skips the file write.
+
+    :param client: GarminClient instance.
+    :param startdate: Range start (``YYYY-MM-DD``, inclusive).
+    :param enddate: Range end (``YYYY-MM-DD``, inclusive). Defaults to ``startdate``.
+    :return: Merged calendar dictionary, or ``None`` when no cycles were found.
+    """
+    startdate = _validate_date_format(startdate, "startdate")
+    if enddate is None:
+        enddate = startdate
+    else:
+        enddate = _validate_date_format(enddate, "enddate")
+
+    start = datetime.strptime(startdate, _DATE_FORMAT_STR).date()
+    end = datetime.strptime(enddate, _DATE_FORMAT_STR).date()
+    if end < start:
+        raise ValueError(
+            f"enddate ({enddate}) must be on or after startdate ({startdate})"
+        )
+
+    chunk_step = timedelta(days=MENSTRUAL_CALENDAR_MAX_DAYS - 1)
+    cycles_by_start: Dict[str, Dict[str, Any]] = {}
+    logged_symptom: set = set()
+    logged_ovulation: set = set()
+    logged_note: set = set()
+
+    chunk_start = start
+    while chunk_start <= end:
+        chunk_end = min(chunk_start + chunk_step, end)
+        url = f"{MENSTRUAL_CALENDAR_URL}/{chunk_start.isoformat()}/{chunk_end.isoformat()}"
+        result = client._connectapi(url)
+        if result:
+            for cycle in result.get("cycleSummaries") or []:
+                cycle_start = cycle.get("startDate")
+                if cycle_start:
+                    cycles_by_start[cycle_start] = cycle
+            logged_symptom.update(result.get("loggedSymptomDays") or [])
+            logged_ovulation.update(result.get("loggedOvulationDays") or [])
+            logged_note.update(result.get("loggedNoteDays") or [])
+        chunk_start = chunk_end + timedelta(days=1)
+
+    if not cycles_by_start:
+        return None
+
+    return {
+        "cycleSummaries": [cycles_by_start[k] for k in sorted(cycles_by_start)],
+        "loggedSymptomDays": sorted(logged_symptom),
+        "loggedOvulationDays": sorted(logged_ovulation),
+        "loggedNoteDays": sorted(logged_note),
+    }
 
 
 # ----------------------------------------------------------------------------------------

--- a/garmin_health_data/garmin_client/client.py
+++ b/garmin_health_data/garmin_client/client.py
@@ -899,6 +899,12 @@ class GarminClient:
         """
         return api.get_intensity_minutes_data(self, cdate)
 
+    def get_menstrual_data_for_date(self, cdate: str) -> Optional[Dict[str, Any]]:
+        """
+        See :func:`api.get_menstrual_data_for_date`.
+        """
+        return api.get_menstrual_data_for_date(self, cdate)
+
     def get_body_composition(
         self, startdate: str, enddate: Optional[str] = None
     ) -> Dict[str, Any]:
@@ -906,6 +912,14 @@ class GarminClient:
         See :func:`api.get_body_composition`.
         """
         return api.get_body_composition(self, startdate, enddate)
+
+    def get_menstrual_calendar_data(
+        self, startdate: str, enddate: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """
+        See :func:`api.get_menstrual_calendar_data`.
+        """
+        return api.get_menstrual_calendar_data(self, startdate, enddate)
 
     def get_activities_by_date(
         self,

--- a/garmin_health_data/garmin_client/constants.py
+++ b/garmin_health_data/garmin_client/constants.py
@@ -122,6 +122,12 @@ RACE_PREDICTOR_URL = "/metrics-service/metrics/racepredictions"
 # Personal records.
 PERSONAL_RECORD_URL = "/personalrecord-service/personalrecord/prs"
 
+# Menstrual cycle (periodic health). Calendar enforces a hard 92-day max range
+# per request; the API wrapper paginates internally for longer windows.
+MENSTRUAL_DAYVIEW_URL = "/periodichealth-service/menstrualcycle/dayview"
+MENSTRUAL_CALENDAR_URL = "/periodichealth-service/menstrualcycle/calendar"
+MENSTRUAL_CALENDAR_MAX_DAYS = 92
+
 # Activities.
 ACTIVITIES_URL = "/activitylist-service/activities/search/activities"
 ACTIVITY_URL = "/activity-service/activity"

--- a/garmin_health_data/models.py
+++ b/garmin_health_data/models.py
@@ -1095,8 +1095,8 @@ class MenstrualCycleDay(Base, UpsertBase):
 
     One row per day inside any observed or predicted cycle window. Combines the dayview
     endpoint's daySummary (computed cycle state, always present when the day falls in a
-    cycle window) and dayLog (user-supplied data, NULL for predicted- cycle days the
-    user has not logged). Re-extracting the same day refreshes scalars via upsert; tag-
+    cycle window) and dayLog (user-supplied data, NULL for predicted-cycle days the user
+    has not logged). Re-extracting the same day refreshes scalars via upsert; tag-
     shaped sub-fields (symptoms, moods, discharge) live in MenstrualCycleTag with
     delete-then-insert semantics on every reprocess.
     """

--- a/garmin_health_data/models.py
+++ b/garmin_health_data/models.py
@@ -1091,12 +1091,14 @@ class ActivityTsMetricDownsampled(Base, InsertBase):
 
 class MenstrualCycleDay(Base, UpsertBase):
     """
-    Daily menstrual cycle log from Garmin Connect's periodic-health service.
+    Daily menstrual cycle state from Garmin Connect's periodic-health service.
 
-    Combines the dayview endpoint's daySummary (computed cycle state) and dayLog (user-
-    supplied data) into one row per logged day. Re-extracting the same day refreshes
-    scalars via upsert; tag-shaped sub-fields (symptoms, moods, discharge) live in
-    MenstrualCycleTag with delete-then-insert semantics on every reprocess.
+    One row per day inside any observed or predicted cycle window. Combines the dayview
+    endpoint's daySummary (computed cycle state, always present when the day falls in a
+    cycle window) and dayLog (user-supplied data, NULL for predicted- cycle days the
+    user has not logged). Re-extracting the same day refreshes scalars via upsert; tag-
+    shaped sub-fields (symptoms, moods, discharge) live in MenstrualCycleTag with
+    delete-then-insert semantics on every reprocess.
     """
 
     __tablename__ = "menstrual_cycle_day"

--- a/garmin_health_data/models.py
+++ b/garmin_health_data/models.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     String,
@@ -1086,3 +1087,83 @@ class ActivityTsMetricDownsampled(Base, InsertBase):
             bucket_ts.desc(),
         ),
     )
+
+
+class MenstrualCycleDay(Base, UpsertBase):
+    """
+    Daily menstrual cycle log from Garmin Connect's periodic-health service.
+
+    Combines the dayview endpoint's daySummary (computed cycle state) and dayLog (user-
+    supplied data) into one row per logged day. Re-extracting the same day refreshes
+    scalars via upsert; tag-shaped sub-fields (symptoms, moods, discharge) live in
+    MenstrualCycleTag with delete-then-insert semantics on every reprocess.
+    """
+
+    __tablename__ = "menstrual_cycle_day"
+
+    user_id = Column(BigInteger, ForeignKey("user.user_id"), primary_key=True)
+    date = Column(Date, primary_key=True)
+    cycle_start_date = Column(Date)
+    day_in_cycle = Column(Integer)
+    period_length = Column(Integer)
+    current_phase = Column(String)
+    length_of_current_phase = Column(Integer)
+    days_until_next_phase = Column(Integer)
+    predicted_cycle_length = Column(Integer)
+    cycle_type = Column(String)
+    predicted_cycle = Column(Boolean)
+    flow = Column(String)
+    sex_drive = Column(String)
+    sexual_activity = Column(String)
+    notes = Column(Text)
+    report_ts = Column(DateTime)
+    has_baby_movement = Column(Boolean)
+    ovulation_day = Column(Boolean)
+
+
+class MenstrualCycleTag(Base, InsertBase):
+    """
+    Polymorphic tag table for symptoms, moods, and discharge logged on a given day.
+
+    Cascade-deletes when the parent menstrual_cycle_day row is removed. Processor uses
+    delete-then-insert per (user_id, date) so user-removed tags propagate.
+    """
+
+    __tablename__ = "menstrual_cycle_tag"
+
+    user_id = Column(BigInteger, primary_key=True)
+    date = Column(Date, primary_key=True)
+    kind = Column(String, primary_key=True)
+    name = Column(String, primary_key=True)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id", "date"],
+            ["menstrual_cycle_day.user_id", "menstrual_cycle_day.date"],
+            ondelete="CASCADE",
+        ),
+        CheckConstraint(
+            "kind IN ('SYMPTOM', 'MOOD', 'DISCHARGE')",
+            name="menstrual_cycle_tag_kind_valid",
+        ),
+        Index("menstrual_cycle_tag_kind_name_idx", "kind", "name"),
+    )
+
+
+class MenstrualCycleSummary(Base, UpsertBase):
+    """
+    Per-cycle summaries from the menstrual cycle calendar endpoint.
+
+    Includes both user-logged cycles (predicted_cycle=False) and Garmin's projections
+    of upcoming cycles (predicted_cycle=True). Predicted rows are wiped and re-inserted
+    on every extract because Garmin's projection dates shift as new data is logged;
+    observed rows use upsert by (user_id, start_date). Cycle length is intentionally
+    not stored: derive in SQL via LEAD(start_date) OVER (...) - start_date.
+    """
+
+    __tablename__ = "menstrual_cycle_summary"
+
+    user_id = Column(BigInteger, ForeignKey("user.user_id"), primary_key=True)
+    start_date = Column(Date, primary_key=True)
+    period_length = Column(Integer)
+    predicted_cycle = Column(Boolean, nullable=False)

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -2524,7 +2524,7 @@ class GarminProcessor(Processor):
 
         # Wipe stale predictions before insert so the table reflects Garmin's
         # current projection set rather than the union of every past projection.
-        session.execute(
+        wipe_result = session.execute(
             delete(MenstrualCycleSummary).where(
                 and_(
                     MenstrualCycleSummary.user_id == int(self.user_id),
@@ -2532,9 +2532,13 @@ class GarminProcessor(Processor):
                 )
             )
         )
+        wiped_predicted = wipe_result.rowcount or 0
 
         if not cycle_summaries:
-            click.echo(f"No cycle summaries in {file_path.name}.")
+            click.echo(
+                f"No cycle summaries in {file_path.name}; "
+                f"wiped {wiped_predicted} stale predicted row(s)."
+            )
             return
 
         records = []
@@ -2563,7 +2567,10 @@ class GarminProcessor(Processor):
                 conflict_columns=["user_id", "start_date"],
                 on_conflict_update=True,
             )
-            click.echo(f"Processed {len(records)} menstrual cycle summary records.")
+            click.echo(
+                f"Processed {len(records)} menstrual cycle summary record(s); "
+                f"wiped {wiped_predicted} stale predicted row(s) first."
+            )
 
     def _process_personal_records(self, file_path: Path, session: Session):
         """

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -28,6 +28,7 @@ from garmin_health_data.constants import (
     GARMIN_DATA_REGISTRY,
     PR_TYPE_LABELS,
     SEMICIRCLES_TO_DEGREES,
+    MenstrualCyclePhase,
     SleepStage,
 )
 from garmin_health_data.models import (
@@ -45,6 +46,9 @@ from garmin_health_data.models import (
     HeartRate,
     HRV,
     IntensityMinutes,
+    MenstrualCycleDay,
+    MenstrualCycleSummary,
+    MenstrualCycleTag,
     PersonalRecord,
     RacePredictions,
     Respiration,
@@ -168,6 +172,8 @@ class GarminProcessor(Processor):
                 ("FLOORS", self._process_floors),
                 ("HEART_RATE", self._process_heart_rate),
                 ("INTENSITY_MINUTES", self._process_intensity_minutes),
+                ("MENSTRUAL_CYCLE_DAY", self._process_menstrual_cycle_day),
+                ("MENSTRUAL_CYCLE_SUMMARY", self._process_menstrual_cycle_summary),
                 ("PERSONAL_RECORDS", self._process_personal_records),
                 ("RACE_PREDICTIONS", self._process_race_predictions),
                 ("RESPIRATION", self._process_respiration),
@@ -2371,6 +2377,193 @@ class GarminProcessor(Processor):
             click.echo(f"Processed {len(floors_records)} floors records.")
         else:
             click.secho("⚠️ No floors data found.", fg="yellow")
+
+    def _process_menstrual_cycle_day(self, file_path: Path, session: Session):
+        """
+        Process a MENSTRUAL_CYCLE_DAY file containing one day's cycle log.
+
+        Upserts the day row keyed by ``(user_id, date)``. Then runs delete-then-insert
+        for that day's tags (symptoms, moods, discharge) so user removals propagate on
+        reprocess. The integer ``daySummary.currentPhase`` is translated to a textual
+        label via ``MenstrualCyclePhase`` and stored denormalized in ``current_phase``;
+        the integer index is not persisted.
+
+        :param file_path: Path to the MENSTRUAL_CYCLE_DAY JSON file.
+        :param session: SQLAlchemy Session object.
+        """
+        payload = self._load_json_file(file_path)
+        day_summary = payload.get("daySummary") or {}
+        day_log = payload.get("dayLog") or {}
+
+        # Recover the data date. Prefer dayLog.calendarDate; fall back to the
+        # filename timestamp (a midday UTC stamp built from the queried date).
+        date_str = day_log.get("calendarDate")
+        if not date_str:
+            ts_str = self._parse_filename(file_path.name)["timestamp"]
+            date_str = ts_str.split("T", 1)[0]
+        day_date = self._parse_date_string(date_str)
+
+        # Translate the numeric phase to a denormalized text label.
+        phase_int = day_summary.get("currentPhase")
+        current_phase_label: Optional[str] = None
+        if phase_int is not None:
+            try:
+                current_phase_label = MenstrualCyclePhase(phase_int).name
+            except ValueError:
+                click.secho(
+                    f"⚠️ Unknown menstrual cycle phase code {phase_int!r} in "
+                    f"{file_path.name}; storing as 'UNKNOWN_{phase_int}'.",
+                    fg="yellow",
+                )
+                current_phase_label = f"UNKNOWN_{phase_int}"
+
+        # Parse cycle start date (may be missing for fully-unlogged days).
+        cycle_start_str = day_summary.get("startDate")
+        cycle_start_date = (
+            self._parse_date_string(cycle_start_str) if cycle_start_str else None
+        )
+
+        # Parse the user's last-edit timestamp.
+        report_ts_str = day_log.get("reportTimestamp")
+        report_ts = self._parse_garmin_iso(report_ts_str) if report_ts_str else None
+
+        day_record = MenstrualCycleDay(
+            user_id=int(self.user_id),
+            date=day_date,
+            cycle_start_date=cycle_start_date,
+            day_in_cycle=day_summary.get("dayInCycle"),
+            period_length=day_summary.get("periodLength"),
+            current_phase=current_phase_label,
+            length_of_current_phase=day_summary.get("lengthOfCurrentPhase"),
+            days_until_next_phase=day_summary.get("daysUntilNextPhase"),
+            predicted_cycle_length=day_summary.get("predictedCycleLength"),
+            cycle_type=day_summary.get("cycleType"),
+            predicted_cycle=day_summary.get("predictedCycle"),
+            flow=day_log.get("flow"),
+            sex_drive=day_log.get("sexDrive"),
+            sexual_activity=day_log.get("sexualActivity"),
+            notes=day_log.get("notes"),
+            report_ts=report_ts,
+            has_baby_movement=day_log.get("hasBabyMovement"),
+            ovulation_day=day_log.get("ovulationDay"),
+        )
+        upsert_model_instances(
+            session=session,
+            model_instances=[day_record],
+            conflict_columns=["user_id", "date"],
+            on_conflict_update=True,
+        )
+
+        # Delete-then-insert per (user_id, date) for all three tag kinds. This is the
+        # only safe pattern because users can REMOVE tags between extracts; a pure
+        # upsert-by-PK would leave orphan rows for removed tags. One DELETE clears
+        # symptoms, moods, and discharge together; one INSERT batch repopulates them.
+        session.execute(
+            delete(MenstrualCycleTag).where(
+                and_(
+                    MenstrualCycleTag.user_id == int(self.user_id),
+                    MenstrualCycleTag.date == day_date,
+                )
+            )
+        )
+
+        # Garmin currently returns each tag list as a flat list of string enums
+        # (e.g. ['BACKACHE', 'CRAMPS']). If a future Garmin change enriches the
+        # shape (e.g. {'name': 'CRAMPS', 'severity': 'MILD'}), skip non-string
+        # entries with a warning rather than silently stringifying the dict into
+        # the `name` column.
+        tag_records: List[MenstrualCycleTag] = []
+        for kind, names in (
+            ("SYMPTOM", day_log.get("symptoms") or []),
+            ("MOOD", day_log.get("moods") or []),
+            ("DISCHARGE", day_log.get("discharge") or []),
+        ):
+            for name in names:
+                if not name:
+                    continue
+                if not isinstance(name, str):
+                    click.secho(
+                        f"⚠️ Skipping non-string {kind} tag in "
+                        f"{file_path.name}: {name!r}.",
+                        fg="yellow",
+                    )
+                    continue
+                tag_records.append(
+                    MenstrualCycleTag(
+                        user_id=int(self.user_id),
+                        date=day_date,
+                        kind=kind,
+                        name=name,
+                    )
+                )
+
+        if tag_records:
+            session.add_all(tag_records)
+
+        click.echo(
+            f"Processed menstrual cycle day for {day_date} "
+            f"({len(tag_records)} tags)."
+        )
+
+    def _process_menstrual_cycle_summary(self, file_path: Path, session: Session):
+        """
+        Process a MENSTRUAL_CYCLE_SUMMARY file from the calendar endpoint.
+
+        Wipes all ``predicted_cycle=True`` rows for the current user before inserting
+        the new payload. Real (user-logged) cycles use upsert by ``(user_id,
+        start_date)`` because their start date is anchored to an observed event and does
+        not drift between extracts. Predictions, by contrast, shift dates as Garmin
+        recomputes projections, so wipe-and-replace is the only way to keep the table
+        mirroring the current Garmin state without accumulating stale predicted rows.
+
+        :param file_path: Path to the MENSTRUAL_CYCLE_SUMMARY JSON file.
+        :param session: SQLAlchemy Session object.
+        """
+        payload = self._load_json_file(file_path)
+        cycle_summaries = payload.get("cycleSummaries") or []
+
+        # Wipe stale predictions before insert so the table reflects Garmin's
+        # current projection set rather than the union of every past projection.
+        session.execute(
+            delete(MenstrualCycleSummary).where(
+                and_(
+                    MenstrualCycleSummary.user_id == int(self.user_id),
+                    MenstrualCycleSummary.predicted_cycle.is_(True),
+                )
+            )
+        )
+
+        if not cycle_summaries:
+            click.echo(f"No cycle summaries in {file_path.name}.")
+            return
+
+        records = []
+        for cycle in cycle_summaries:
+            start_date_str = cycle.get("startDate")
+            if not start_date_str:
+                click.secho(
+                    f"⚠️ Skipping cycle summary entry with no startDate in "
+                    f"{file_path.name}: {cycle}",
+                    fg="yellow",
+                )
+                continue
+            records.append(
+                MenstrualCycleSummary(
+                    user_id=int(self.user_id),
+                    start_date=self._parse_date_string(start_date_str),
+                    period_length=cycle.get("periodLength"),
+                    predicted_cycle=bool(cycle.get("predictedCycle", False)),
+                )
+            )
+
+        if records:
+            upsert_model_instances(
+                session=session,
+                model_instances=records,
+                conflict_columns=["user_id", "start_date"],
+                on_conflict_update=True,
+            )
+            click.echo(f"Processed {len(records)} menstrual cycle summary records.")
 
     def _process_personal_records(self, file_path: Path, session: Session):
         """

--- a/garmin_health_data/tables.ddl
+++ b/garmin_health_data/tables.ddl
@@ -592,6 +592,72 @@ CREATE TABLE IF NOT EXISTS floors (
 CREATE INDEX IF NOT EXISTS floors_user_id_timestamp_idx
 ON floors (user_id, timestamp DESC);
 
+-- Daily menstrual cycle log from Garmin Connect's periodic-health service. One row per logged day. Combines the dayview endpoint's daySummary (computed cycle state) and dayLog (user-supplied data). Logged days outside any cycle are skipped at extract time. Re-extracting the same day refreshes the row in place via upsert; tag-shaped sub-fields (symptoms, moods, discharge) live in menstrual_cycle_tag with delete-then-insert per (user_id, date) semantics so user removals propagate.
+CREATE TABLE IF NOT EXISTS menstrual_cycle_day (
+    user_id BIGINT NOT NULL              -- References user(user_id). Identifies which user this log belongs to.
+    , date DATE NOT NULL                   -- Calendar date of the log (dayLog.calendarDate, or the queried date when only daySummary is present).
+    , cycle_start_date DATE                -- daySummary.startDate. Most recent period start anchoring this day's day-in-cycle.
+    , day_in_cycle INTEGER                 -- 1-based day index within the current cycle (daySummary.dayInCycle).
+    , period_length INTEGER                -- Length of the current period in days (daySummary.periodLength).
+    , current_phase TEXT                   -- Denormalized phase label: MENSTRUAL / FOLLICULAR / OVULATORY / LUTEAL. Sourced from daySummary.currentPhase (1-4 int) via MenstrualCyclePhase.
+    , length_of_current_phase INTEGER      -- daySummary.lengthOfCurrentPhase.
+    , days_until_next_phase INTEGER        -- daySummary.daysUntilNextPhase.
+    , predicted_cycle_length INTEGER       -- daySummary.predictedCycleLength.
+    , cycle_type TEXT                      -- daySummary.cycleType (e.g., ''REGULAR'', ''IRREGULAR'').
+    , predicted_cycle BOOLEAN              -- daySummary.predictedCycle. TRUE means the cycle is a projection, FALSE means a user-logged period.
+    , flow TEXT                            -- dayLog.flow: NONE / LIGHT / MEDIUM / HEAVY. Nullable when not logged.
+    , sex_drive TEXT                       -- dayLog.sexDrive: NONE / LOW / AVERAGE / HIGH. Nullable.
+    , sexual_activity TEXT                 -- dayLog.sexualActivity: NONE / UNPROTECTED / PROTECTED. Nullable.
+    , notes TEXT                           -- dayLog.notes. Freeform user text. Nullable.
+    , report_ts DATETIME                   -- dayLog.reportTimestamp. Last time the user edited this day's log.
+    , has_baby_movement BOOLEAN            -- dayLog.hasBabyMovement.
+    , ovulation_day BOOLEAN                -- dayLog.ovulationDay. User-marked ovulation flag.
+    , create_ts DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP  -- Timestamp when the record was created in the database.
+    , update_ts DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP  -- Timestamp when the record was last modified in the database.
+    , PRIMARY KEY (user_id, date)
+    , FOREIGN KEY (user_id) REFERENCES user (user_id)
+);
+
+CREATE INDEX IF NOT EXISTS menstrual_cycle_day_user_id_date_idx
+ON menstrual_cycle_day (user_id, date DESC);
+
+-- Polymorphic tag table for the three list-shaped fields on the dayview dayLog: symptoms, moods, and discharge. Each row is one tag the user logged on one day. Names are raw Garmin enum identifiers (e.g., ''BACKACHE'', ''HAPPY'', ''EGG_WHITE''). Processor uses delete-then-insert per (user_id, date) so tags removed by the user propagate on the next extract.
+CREATE TABLE IF NOT EXISTS menstrual_cycle_tag (
+    user_id BIGINT NOT NULL              -- References menstrual_cycle_day(user_id).
+    , date DATE NOT NULL                   -- References menstrual_cycle_day(date).
+    , kind TEXT NOT NULL                   -- One of: SYMPTOM, MOOD, DISCHARGE.
+    , name TEXT NOT NULL                   -- Raw Garmin enum identifier for the tag.
+    , create_ts DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP  -- Timestamp when the record was created in the database.
+    , PRIMARY KEY (user_id, date, kind, name)
+    , FOREIGN KEY (user_id, date) REFERENCES menstrual_cycle_day (
+        user_id, date
+    ) ON DELETE CASCADE
+    , CONSTRAINT menstrual_cycle_tag_kind_valid CHECK (
+        kind IN ('SYMPTOM', 'MOOD', 'DISCHARGE')
+    )
+);
+
+CREATE INDEX IF NOT EXISTS menstrual_cycle_tag_kind_name_idx
+ON menstrual_cycle_tag (kind, name);
+
+-- Per-cycle summaries from the menstrual cycle calendar endpoint. Includes both user-logged cycles (predicted_cycle=0) and Garmin's projections of upcoming cycles (predicted_cycle=1). Cycle length is intentionally not stored; derive in SQL via LEAD(start_date) OVER (PARTITION BY user_id ORDER BY start_date) - start_date. Predicted rows are wiped and re-inserted on every extract because Garmin's projection dates shift as new data is logged; observed rows use upsert by (user_id, start_date).
+CREATE TABLE IF NOT EXISTS menstrual_cycle_summary (
+    user_id BIGINT NOT NULL              -- References user(user_id).
+    , start_date DATE NOT NULL             -- cycleSummaries[].startDate. Day the period began (or is predicted to begin).
+    , period_length INTEGER                -- cycleSummaries[].periodLength. Length of the period in days.
+    , predicted_cycle BOOLEAN NOT NULL     -- cycleSummaries[].predictedCycle. TRUE for Garmin projections, FALSE for user-logged cycles.
+    , create_ts DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP  -- Timestamp when the record was created in the database.
+    , update_ts DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP  -- Timestamp when the record was last modified in the database.
+    , PRIMARY KEY (user_id, start_date)
+    , FOREIGN KEY (user_id) REFERENCES user (user_id)
+);
+
+CREATE INDEX IF NOT EXISTS menstrual_cycle_summary_user_id_start_date_idx
+ON menstrual_cycle_summary (user_id, start_date DESC);
+
+CREATE INDEX IF NOT EXISTS menstrual_cycle_summary_predicted_cycle_idx
+ON menstrual_cycle_summary (user_id, predicted_cycle);
+
 -- Personal records achieved by users across various activity types and distances.
 CREATE TABLE IF NOT EXISTS personal_record (
     user_id BIGINT NOT NULL              -- Foreign key reference to the user profile.

--- a/garmin_health_data/tables.ddl
+++ b/garmin_health_data/tables.ddl
@@ -592,7 +592,7 @@ CREATE TABLE IF NOT EXISTS floors (
 CREATE INDEX IF NOT EXISTS floors_user_id_timestamp_idx
 ON floors (user_id, timestamp DESC);
 
--- Daily menstrual cycle log from Garmin Connect's periodic-health service. One row per logged day. Combines the dayview endpoint's daySummary (computed cycle state) and dayLog (user-supplied data). Logged days outside any cycle are skipped at extract time. Re-extracting the same day refreshes the row in place via upsert; tag-shaped sub-fields (symptoms, moods, discharge) live in menstrual_cycle_tag with delete-then-insert per (user_id, date) semantics so user removals propagate.
+-- Daily menstrual cycle state from Garmin Connect's periodic-health service. One row per day inside any observed or predicted cycle window. Combines the dayview endpoint's daySummary (computed cycle state, always present) and dayLog (user-supplied data, NULL for days the user has not logged but that still fall inside a known or predicted cycle). Days outside every cycle window return a bare empty payload from the API and are skipped at extract time. Re-extracting the same day refreshes the row in place via upsert; tag-shaped sub-fields (symptoms, moods, discharge) live in menstrual_cycle_tag with delete-then-insert per (user_id, date) semantics so user removals propagate.
 CREATE TABLE IF NOT EXISTS menstrual_cycle_day (
     user_id BIGINT NOT NULL              -- References user(user_id). Identifies which user this log belongs to.
     , date DATE NOT NULL                   -- Calendar date of the log (dayLog.calendarDate, or the queried date when only daySummary is present).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garmin-health-data"
-version = "2.10.0"
+version = "2.11.0"
 description = "Extract your Garmin Connect health data to a local SQLite database"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_auth_extended.py
+++ b/tests/test_auth_extended.py
@@ -148,19 +148,22 @@ class TestRefreshTokens:
         self,
         mock_echo: MagicMock,
         mock_garmin_class: MagicMock,
+        tmp_path: Path,
     ) -> None:
         """
         Test successful token refresh without MFA.
 
         :param mock_echo: Mock click.echo function.
         :param mock_garmin_class: Mock Garmin class.
+        :param tmp_path: Per-test token directory so the real auth code does not pollute
+            ``~/.garminconnect/`` with the mocked profile id.
         """
         mock_garmin = MagicMock()
         mock_garmin.login.return_value = None
         mock_garmin.get_user_profile.return_value = {"id": "12345678"}
         mock_garmin_class.return_value = mock_garmin
 
-        refresh_tokens("test@example.com", "password123")
+        refresh_tokens("test@example.com", "password123", base_token_dir=str(tmp_path))
 
         mock_garmin_class.assert_called_once()
         mock_garmin.login.assert_called_once()
@@ -175,6 +178,7 @@ class TestRefreshTokens:
         mock_echo: MagicMock,
         mock_get_mfa: MagicMock,
         mock_garmin_class: MagicMock,
+        tmp_path: Path,
     ) -> None:
         """
         Test successful token refresh with MFA.
@@ -182,6 +186,8 @@ class TestRefreshTokens:
         :param mock_echo: Mock click.echo function.
         :param mock_get_mfa: Mock get_mfa_code function.
         :param mock_garmin_class: Mock Garmin class.
+        :param tmp_path: Per-test token directory so the real auth code does not pollute
+            ``~/.garminconnect/`` with the mocked profile id.
         """
         mock_get_mfa.return_value = "123456"
         mock_garmin = MagicMock()
@@ -189,7 +195,7 @@ class TestRefreshTokens:
         mock_garmin.get_user_profile.return_value = {"id": "12345678"}
         mock_garmin_class.return_value = mock_garmin
 
-        refresh_tokens("test@example.com", "password123")
+        refresh_tokens("test@example.com", "password123", base_token_dir=str(tmp_path))
 
         mock_garmin_class.assert_called_once()
         mock_garmin.login.assert_called_once()
@@ -205,6 +211,7 @@ class TestRefreshTokens:
         mock_secho: MagicMock,
         mock_echo: MagicMock,
         mock_garmin_class: MagicMock,
+        tmp_path: Path,
     ) -> None:
         """
         Test token refresh failure with invalid credentials.
@@ -212,6 +219,8 @@ class TestRefreshTokens:
         :param mock_secho: Mock click.secho function.
         :param mock_echo: Mock click.echo function.
         :param mock_garmin_class: Mock Garmin class.
+        :param tmp_path: Per-test token directory so the real auth code does not pollute
+            ``~/.garminconnect/`` if it ever reaches the mkdir step.
         """
         import click
 
@@ -220,7 +229,11 @@ class TestRefreshTokens:
         mock_garmin_class.return_value = mock_garmin
 
         with pytest.raises(click.ClickException, match="Authentication failed"):
-            refresh_tokens("invalid@example.com", "wrong_password")
+            refresh_tokens(
+                "invalid@example.com",
+                "wrong_password",
+                base_token_dir=str(tmp_path),
+            )
 
         # Should not call dump if login fails.
         mock_garmin.dump.assert_not_called()
@@ -233,6 +246,7 @@ class TestRefreshTokens:
         mock_echo: MagicMock,
         mock_get_mfa: MagicMock,
         mock_garmin_class: MagicMock,
+        tmp_path: Path,
     ) -> None:
         """
         Test MFA authentication with retry on first failure.
@@ -240,6 +254,8 @@ class TestRefreshTokens:
         :param mock_echo: Mock click.echo function.
         :param mock_get_mfa: Mock get_mfa_code function.
         :param mock_garmin_class: Mock Garmin class.
+        :param tmp_path: Per-test token directory so the real auth code does not pollute
+            ``~/.garminconnect/`` with the mocked profile id.
         """
         mock_get_mfa.side_effect = ["000000", "123456"]
         mock_garmin = MagicMock()
@@ -251,7 +267,7 @@ class TestRefreshTokens:
         mock_garmin.get_user_profile.return_value = {"id": "12345678"}
         mock_garmin_class.return_value = mock_garmin
 
-        refresh_tokens("test@example.com", "password123")
+        refresh_tokens("test@example.com", "password123", base_token_dir=str(tmp_path))
 
         assert mock_garmin.resume_login.call_count == 2
         mock_garmin.dump.assert_called_once()

--- a/tests/test_garmin_client_api.py
+++ b/tests/test_garmin_client_api.py
@@ -274,14 +274,15 @@ class TestGetMenstrualCalendarData:
 
         api.get_menstrual_calendar_data(client, "2026-01-01", "2026-06-30")
 
-        # Six months ~= 181 days, needs >=3 chunks at 92 days each.
-        assert client._connectapi.call_count >= 2
+        # 2026-01-01 .. 2026-06-30 inclusive is 181 days; at a 92-day max range per
+        # request, that's exactly 2 chunks: 2026-01-01..2026-04-02 (92 days) and
+        # 2026-04-03..2026-06-30 (89 days).
+        assert client._connectapi.call_count == 2
         called_urls = [c.args[0] for c in client._connectapi.call_args_list]
-        # First chunk starts at requested start.
+        # First chunk starts at requested start, last chunk ends at requested end,
+        # chunks are contiguous (chunk 2's start == chunk 1's end + 1 day).
         assert called_urls[0].endswith("/2026-01-01/2026-04-02")
-        # Chunks are contiguous (each start == prior end + 1 day).
-        # Last chunk ends at requested end.
-        assert called_urls[-1].endswith("/2026-06-30")
+        assert called_urls[1].endswith("/2026-04-03/2026-06-30")
 
     def test_merges_cycle_summaries_dedup_by_start_date(self) -> None:
         """
@@ -346,9 +347,15 @@ class TestGetMenstrualCalendarData:
         assert result["loggedOvulationDays"] == ["2026-05-25"]
         assert result["loggedNoteDays"] == ["2026-03-04"]
 
-    def test_returns_none_when_no_cycles(self) -> None:
+    def test_empty_cycles_response_returns_merged_shape(self) -> None:
         """
-        All chunks empty -> None.
+        A successful response with no cycles must still return the merged shape (empty
+        arrays) so the file lands and ``_process_menstrual_cycle_summary`` runs its
+        wipe-and-replace policy for stale predicted rows.
+
+        Without this, a user who stopped tracking cycles (or who has none in the queried
+        window) would leave previously-extracted predicted rows stranded in the database
+        forever, since the processor would never run.
         """
         client = MagicMock()
         client._connectapi.return_value = {
@@ -360,11 +367,18 @@ class TestGetMenstrualCalendarData:
 
         result = api.get_menstrual_calendar_data(client, "2026-04-01", "2026-05-25")
 
-        assert result is None
+        assert result is not None
+        assert result["cycleSummaries"] == []
+        assert result["loggedSymptomDays"] == []
 
     def test_returns_none_when_all_chunks_return_none(self) -> None:
         """
-        Defensive: all-None responses across all chunks treated as no data.
+        Distinct from the empty-but-successful case above: when every chunk's HTTP call
+        returns ``None`` (e.g. a transport failure swallowed by the retry layer), the
+        wrapper returns ``None`` so the extractor skips writing a file.
+
+        We have no signal at all in that case, so there's nothing for the processor to
+        act on.
         """
         client = MagicMock()
         client._connectapi.return_value = None

--- a/tests/test_garmin_client_api.py
+++ b/tests/test_garmin_client_api.py
@@ -116,11 +116,15 @@ class TestGetBodyComposition:
 
 class TestGetMenstrualDataForDate:
     """
-    Tests for :func:`api.get_menstrual_data_for_date` empty-response normalization.
+    Tests for :func:`api.get_menstrual_data_for_date` response-shape normalization.
 
-    The Garmin dayview endpoint returns a bare ``{}`` for unlogged days, which the
-    extractor's generic truthiness check would otherwise misclassify as non-empty.
-    ``get_menstrual_data_for_date`` must collapse that shape to ``None``.
+    The dayview endpoint returns a bare ``{}`` for days outside every cycle window. That
+    alone would be filtered by the extractor's ``if data:`` truthiness check (``{}`` is
+    falsy in Python). The wrapper's additional value is filtering *truthy* response
+    shapes that lack the expected ``daySummary`` / ``dayLog`` keys (e.g. an unexpected
+    wrapper-only dict) so the extractor never persists meaningless payloads. These tests
+    cover both the falsy-empty and truthy-but- unknown paths, plus the happy-path
+    passthroughs.
     """
 
     def test_returns_payload_when_logged(self) -> None:

--- a/tests/test_garmin_client_api.py
+++ b/tests/test_garmin_client_api.py
@@ -112,3 +112,282 @@ class TestGetBodyComposition:
             api.WEIGHT_DATERANGE_URL,
             params={"startDate": "2026-04-15", "endDate": "2026-04-15"},
         )
+
+
+class TestGetMenstrualDataForDate:
+    """
+    Tests for :func:`api.get_menstrual_data_for_date` empty-response normalization.
+
+    The Garmin dayview endpoint returns a bare ``{}`` for unlogged days, which the
+    extractor's generic truthiness check would otherwise misclassify as non-empty.
+    ``get_menstrual_data_for_date`` must collapse that shape to ``None``.
+    """
+
+    def test_returns_payload_when_logged(self) -> None:
+        """
+        A populated dayview response with both ``daySummary`` and ``dayLog`` must be
+        returned verbatim so the extractor saves the file and the processor can map
+        fields downstream.
+        """
+        payload = {
+            "daySummary": {
+                "startDate": "2026-05-23",
+                "dayInCycle": 3,
+                "periodLength": 3,
+                "currentPhase": 1,
+                "lengthOfCurrentPhase": 3,
+                "daysUntilNextPhase": 1,
+                "predictedCycleLength": 28,
+                "cycleType": "REGULAR",
+                "predictedCycle": False,
+            },
+            "dayLog": {
+                "userProfilePk": 15007510,
+                "calendarDate": "2026-05-25",
+                "symptoms": ["BACKACHE", "CRAMPS"],
+                "moods": ["HAPPY"],
+                "discharge": ["CREAMY"],
+                "flow": "HEAVY",
+                "sexDrive": "AVERAGE",
+                "sexualActivity": "PROTECTED",
+                "notes": "test",
+                "reportTimestamp": "2026-05-25T18:34:49.9",
+                "hasBabyMovement": False,
+                "ovulationDay": True,
+            },
+        }
+        client = MagicMock()
+        client._connectapi.return_value = payload
+
+        result = api.get_menstrual_data_for_date(client, "2026-05-25")
+
+        assert result is payload
+        client._connectapi.assert_called_once_with(
+            f"{api.MENSTRUAL_DAYVIEW_URL}/2026-05-25"
+        )
+
+    def test_returns_payload_with_only_day_summary(self) -> None:
+        """
+        Garmin can return a daySummary without a dayLog when the day falls in a
+        predicted cycle window the user hasn't logged.
+
+        Pass it through; the processor will skip the dayLog scalars.
+        """
+        payload = {
+            "daySummary": {
+                "startDate": "2026-05-23",
+                "dayInCycle": 5,
+                "currentPhase": 2,
+                "predictedCycle": True,
+            }
+        }
+        client = MagicMock()
+        client._connectapi.return_value = payload
+
+        result = api.get_menstrual_data_for_date(client, "2026-05-27")
+
+        assert result is payload
+
+    def test_returns_none_when_empty_dict(self) -> None:
+        """
+        Unlogged days outside any cycle window return ``{}``.
+
+        Must collapse to None.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = {}
+
+        result = api.get_menstrual_data_for_date(client, "2026-05-25")
+
+        assert result is None
+
+    def test_returns_none_when_response_is_none(self) -> None:
+        """
+        Transient empty-body responses pass through as ``None``.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = None
+
+        result = api.get_menstrual_data_for_date(client, "2026-05-25")
+
+        assert result is None
+
+    def test_returns_none_when_only_unknown_keys(self) -> None:
+        """
+        Defensive: if the endpoint returns a wrapper with neither daySummary nor dayLog,
+        treat as no data rather than letting an unknown shape through.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = {"unexpected": "shape"}
+
+        result = api.get_menstrual_data_for_date(client, "2026-05-25")
+
+        assert result is None
+
+
+class TestGetMenstrualCalendarData:
+    """
+    Tests for :func:`api.get_menstrual_calendar_data` covering both empty-response
+    normalization and the 92-day pagination loop.
+    """
+
+    def test_returns_payload_for_single_chunk(self) -> None:
+        """
+        For a range within the 92-day API limit, the wrapper issues exactly one HTTP
+        call and returns the merged payload.
+        """
+        cycle_payload = {
+            "cycleSummaries": [
+                {
+                    "startDate": "2026-05-23",
+                    "periodLength": 3,
+                    "predictedCycle": False,
+                }
+            ],
+            "loggedSymptomDays": ["2026-05-25"],
+            "loggedOvulationDays": [],
+            "loggedNoteDays": ["2026-05-25"],
+        }
+        client = MagicMock()
+        client._connectapi.return_value = cycle_payload
+
+        result = api.get_menstrual_calendar_data(client, "2026-04-01", "2026-05-25")
+
+        assert client._connectapi.call_count == 1
+        assert result is not None
+        assert result["cycleSummaries"] == cycle_payload["cycleSummaries"]
+        assert result["loggedSymptomDays"] == ["2026-05-25"]
+
+    def test_paginates_when_range_exceeds_92_days(self) -> None:
+        """
+        Ranges longer than 92 days are split into contiguous sub-windows.
+
+        Verify the wrapper issues multiple HTTP calls with non-overlapping date pairs
+        that fully cover the requested range.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = {"cycleSummaries": []}
+
+        api.get_menstrual_calendar_data(client, "2026-01-01", "2026-06-30")
+
+        # Six months ~= 181 days, needs >=3 chunks at 92 days each.
+        assert client._connectapi.call_count >= 2
+        called_urls = [c.args[0] for c in client._connectapi.call_args_list]
+        # First chunk starts at requested start.
+        assert called_urls[0].endswith("/2026-01-01/2026-04-02")
+        # Chunks are contiguous (each start == prior end + 1 day).
+        # Last chunk ends at requested end.
+        assert called_urls[-1].endswith("/2026-06-30")
+
+    def test_merges_cycle_summaries_dedup_by_start_date(self) -> None:
+        """
+        A cycle that straddles a chunk boundary may appear in adjacent chunks.
+
+        The wrapper must dedupe on startDate so the result contains one entry per cycle.
+        """
+        chunk_one = {
+            "cycleSummaries": [
+                {"startDate": "2026-03-01", "periodLength": 5, "predictedCycle": False}
+            ],
+            "loggedSymptomDays": [],
+            "loggedOvulationDays": [],
+            "loggedNoteDays": [],
+        }
+        chunk_two = {
+            "cycleSummaries": [
+                # Same cycle reappears in second chunk.
+                {"startDate": "2026-03-01", "periodLength": 5, "predictedCycle": False},
+                {"startDate": "2026-05-23", "periodLength": 3, "predictedCycle": False},
+            ],
+            "loggedSymptomDays": [],
+            "loggedOvulationDays": [],
+            "loggedNoteDays": [],
+        }
+        client = MagicMock()
+        client._connectapi.side_effect = [chunk_one, chunk_two]
+
+        result = api.get_menstrual_calendar_data(client, "2026-01-01", "2026-05-25")
+
+        assert result is not None
+        starts = [c["startDate"] for c in result["cycleSummaries"]]
+        assert starts == ["2026-03-01", "2026-05-23"]
+
+    def test_merges_logged_day_arrays_across_chunks(self) -> None:
+        """
+        Logged-day arrays merge into sorted unique lists across chunks.
+        """
+        chunk_one = {
+            "cycleSummaries": [
+                {"startDate": "2026-03-01", "periodLength": 5, "predictedCycle": False}
+            ],
+            "loggedSymptomDays": ["2026-03-02"],
+            "loggedOvulationDays": [],
+            "loggedNoteDays": ["2026-03-04"],
+        }
+        chunk_two = {
+            "cycleSummaries": [
+                {"startDate": "2026-05-23", "periodLength": 3, "predictedCycle": False}
+            ],
+            "loggedSymptomDays": ["2026-05-25", "2026-03-02"],
+            "loggedOvulationDays": ["2026-05-25"],
+            "loggedNoteDays": [],
+        }
+        client = MagicMock()
+        client._connectapi.side_effect = [chunk_one, chunk_two]
+
+        result = api.get_menstrual_calendar_data(client, "2026-01-01", "2026-05-25")
+
+        assert result is not None
+        assert result["loggedSymptomDays"] == ["2026-03-02", "2026-05-25"]
+        assert result["loggedOvulationDays"] == ["2026-05-25"]
+        assert result["loggedNoteDays"] == ["2026-03-04"]
+
+    def test_returns_none_when_no_cycles(self) -> None:
+        """
+        All chunks empty -> None.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = {
+            "cycleSummaries": [],
+            "loggedSymptomDays": [],
+            "loggedOvulationDays": [],
+            "loggedNoteDays": [],
+        }
+
+        result = api.get_menstrual_calendar_data(client, "2026-04-01", "2026-05-25")
+
+        assert result is None
+
+    def test_returns_none_when_all_chunks_return_none(self) -> None:
+        """
+        Defensive: all-None responses across all chunks treated as no data.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = None
+
+        result = api.get_menstrual_calendar_data(client, "2026-04-01", "2026-05-25")
+
+        assert result is None
+
+    def test_default_enddate_matches_startdate(self) -> None:
+        """
+        When ``enddate`` is omitted, ``startdate`` is used for both bounds.
+        """
+        client = MagicMock()
+        client._connectapi.return_value = {"cycleSummaries": []}
+
+        api.get_menstrual_calendar_data(client, "2026-05-25")
+
+        client._connectapi.assert_called_once()
+        url = client._connectapi.call_args.args[0]
+        assert url.endswith("/2026-05-25/2026-05-25")
+
+    def test_raises_on_backwards_range(self) -> None:
+        """
+        Enddate before startdate must raise rather than silently looping forever.
+        """
+        import pytest
+
+        client = MagicMock()
+        with pytest.raises(ValueError, match="on or after"):
+            api.get_menstrual_calendar_data(client, "2026-05-25", "2026-05-01")

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -7,7 +7,7 @@ strength training data processing.
 
 import copy
 import json
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -25,6 +25,9 @@ from garmin_health_data.models import (
     ActivityTsMetric,
     BodyComposition,
     BreathingDisruption,
+    MenstrualCycleDay,
+    MenstrualCycleSummary,
+    MenstrualCycleTag,
     Sleep,
     SleepLevel,
     SleepMovement,
@@ -1941,6 +1944,423 @@ class TestProcessBodyComposition:
 
         rows = db_session.execute(select(BodyComposition)).scalars().all()
         assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Menstrual cycle tests ----------------------------------------------------
+# ---------------------------------------------------------------------------
+
+
+def _menstrual_day_payload(
+    symptoms=None,
+    moods=None,
+    discharge=None,
+    phase=1,
+    flow="HEAVY",
+    notes="test",
+    ovulation_day=True,
+    report_ts="2026-05-25T18:34:49.9",
+    calendar_date="2026-05-25",
+    cycle_start_date="2026-05-23",
+):
+    """
+    Build a representative MENSTRUAL_CYCLE_DAY JSON payload (probe-shaped).
+    """
+    return {
+        "daySummary": {
+            "startDate": cycle_start_date,
+            "dayInCycle": 3,
+            "periodLength": 3,
+            "currentPhase": phase,
+            "lengthOfCurrentPhase": 3,
+            "daysUntilNextPhase": 1,
+            "predictedCycleLength": 28,
+            "cycleType": "REGULAR",
+            "predictedCycle": False,
+        },
+        "dayLog": {
+            "userProfilePk": 999,
+            "calendarDate": calendar_date,
+            "symptoms": symptoms if symptoms is not None else ["BACKACHE", "CRAMPS"],
+            "moods": moods if moods is not None else ["HAPPY"],
+            "discharge": discharge if discharge is not None else ["CREAMY"],
+            "flow": flow,
+            "sexDrive": "AVERAGE",
+            "sexualActivity": "PROTECTED",
+            "notes": notes,
+            "reportTimestamp": report_ts,
+            "hasBabyMovement": False,
+            "ovulationDay": ovulation_day,
+        },
+    }
+
+
+def _seed_user_999(db_session: Session) -> None:
+    """
+    Seed user_id=999 so menstrual_cycle_day FK targets exist.
+    """
+    upsert_model_instances(
+        session=db_session,
+        model_instances=[User(user_id=999, full_name="Test")],
+        conflict_columns=["user_id"],
+        on_conflict_update=True,
+    )
+    db_session.commit()
+
+
+def _menstrual_processor(user_id=999) -> GarminProcessor:
+    """
+    Build a GarminProcessor wired with the test user_id.
+    """
+    proc = GarminProcessor(FileSet(file_paths=[], files={}), MagicMock())
+    proc.user_id = user_id
+    return proc
+
+
+class TestProcessMenstrualCycleDay:
+    """
+    Tests for _process_menstrual_cycle_day covering scalar upsert and the critical
+    delete-then-reinsert semantics for tag-shaped fields (symptoms, moods, discharge),
+    which let user-removed tags propagate on reprocess.
+    """
+
+    def test_insert_day_and_tags(self, db_session: Session, tmp_path):
+        """
+        First-time insert populates the day row and all three tag kinds.
+        """
+        _seed_user_999(db_session)
+
+        data = _menstrual_day_payload()
+        file_path = tmp_path / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        proc = _menstrual_processor()
+        proc._process_menstrual_cycle_day(file_path, db_session)
+        db_session.commit()
+
+        day = db_session.execute(select(MenstrualCycleDay)).scalars().one()
+        assert day.user_id == 999
+        assert str(day.date) == "2026-05-25"
+        assert day.current_phase == "MENSTRUAL"
+        assert day.day_in_cycle == 3
+        assert day.predicted_cycle is False
+        assert day.flow == "HEAVY"
+        assert day.notes == "test"
+        assert day.ovulation_day is True
+
+        tags = db_session.execute(select(MenstrualCycleTag)).scalars().all()
+        # 2 symptoms + 1 mood + 1 discharge = 4.
+        assert len(tags) == 4
+        by_kind = {(t.kind, t.name) for t in tags}
+        assert ("SYMPTOM", "BACKACHE") in by_kind
+        assert ("SYMPTOM", "CRAMPS") in by_kind
+        assert ("MOOD", "HAPPY") in by_kind
+        assert ("DISCHARGE", "CREAMY") in by_kind
+
+    def test_reprocess_updates_scalars(self, db_session: Session, tmp_path):
+        """
+        UPSERT semantics: reprocessing the same day with edited scalars overwrites the
+        existing row in place rather than appending a new one.
+        """
+        _seed_user_999(db_session)
+
+        file_path = tmp_path / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(_menstrual_day_payload(flow="LIGHT", notes="initial"), f)
+
+        proc = _menstrual_processor()
+        proc._process_menstrual_cycle_day(file_path, db_session)
+        db_session.commit()
+
+        # User edits the day on Garmin Connect; rewrite the file with new values.
+        with open(file_path, "w") as f:
+            json.dump(_menstrual_day_payload(flow="HEAVY", notes="edited"), f)
+
+        proc._process_menstrual_cycle_day(file_path, db_session)
+        db_session.commit()
+
+        rows = db_session.execute(select(MenstrualCycleDay)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].flow == "HEAVY"
+        assert rows[0].notes == "edited"
+
+    def test_tag_removal_propagates(self, db_session: Session, tmp_path):
+        """
+        Critical scenario: a user removes a previously-logged symptom on Garmin Connect.
+
+        The next extract must reflect the removal, not leave an orphan row. Validates
+        the delete-then-reinsert pattern.
+        """
+        _seed_user_999(db_session)
+
+        file_path = tmp_path / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        # Start with three symptoms.
+        with open(file_path, "w") as f:
+            json.dump(
+                _menstrual_day_payload(
+                    symptoms=["BACKACHE", "CRAMPS", "HEADACHE"],
+                    moods=["HAPPY"],
+                    discharge=["CREAMY"],
+                ),
+                f,
+            )
+
+        proc = _menstrual_processor()
+        proc._process_menstrual_cycle_day(file_path, db_session)
+        db_session.commit()
+
+        # User removes two symptoms and the mood; only BACKACHE remains.
+        with open(file_path, "w") as f:
+            json.dump(
+                _menstrual_day_payload(
+                    symptoms=["BACKACHE"], moods=[], discharge=["CREAMY"]
+                ),
+                f,
+            )
+        proc._process_menstrual_cycle_day(file_path, db_session)
+        db_session.commit()
+
+        tags = db_session.execute(select(MenstrualCycleTag)).scalars().all()
+        by_kind = {(t.kind, t.name) for t in tags}
+        assert by_kind == {("SYMPTOM", "BACKACHE"), ("DISCHARGE", "CREAMY")}
+
+    def test_phase_label_mapping(self, db_session: Session, tmp_path):
+        """
+        Integer currentPhase translates to the denormalized text label.
+        """
+        _seed_user_999(db_session)
+
+        file_path = tmp_path / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(_menstrual_day_payload(phase=3), f)
+
+        proc = _menstrual_processor()
+        proc._process_menstrual_cycle_day(file_path, db_session)
+        db_session.commit()
+
+        day = db_session.execute(select(MenstrualCycleDay)).scalars().one()
+        assert day.current_phase == "OVULATORY"
+
+    def test_unknown_phase_label_stored_with_fallback(
+        self, db_session: Session, tmp_path
+    ):
+        """
+        Defensive: unknown phase integers are stored as 'UNKNOWN_<n>' rather than
+        crashing the processor.
+        """
+        _seed_user_999(db_session)
+
+        file_path = tmp_path / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(_menstrual_day_payload(phase=99), f)
+
+        proc = _menstrual_processor()
+        proc._process_menstrual_cycle_day(file_path, db_session)
+        db_session.commit()
+
+        day = db_session.execute(select(MenstrualCycleDay)).scalars().one()
+        assert day.current_phase == "UNKNOWN_99"
+
+    def test_deleting_day_cascades_to_tags(self, db_session: Session, tmp_path):
+        """
+        FK with ON DELETE CASCADE means removing the parent day row removes its tag
+        children automatically.
+        """
+        _seed_user_999(db_session)
+
+        file_path = tmp_path / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(_menstrual_day_payload(), f)
+
+        proc = _menstrual_processor()
+        proc._process_menstrual_cycle_day(file_path, db_session)
+        db_session.commit()
+
+        assert (
+            db_session.execute(select(func.count(MenstrualCycleTag.name))).scalar() > 0
+        )
+
+        day = db_session.execute(select(MenstrualCycleDay)).scalars().one()
+        db_session.delete(day)
+        db_session.commit()
+
+        assert (
+            db_session.execute(select(func.count(MenstrualCycleTag.name))).scalar() == 0
+        )
+
+    def test_non_string_tag_entries_skipped(self, db_session: Session, tmp_path):
+        """
+        Defensive: if Garmin ever enriches the tag list shape (e.g. to dicts with a
+        severity field), the processor must skip non-string entries with a warning
+        rather than stringifying them into the ``name`` column.
+
+        Valid string entries in the same list still land.
+        """
+        _seed_user_999(db_session)
+
+        payload = _menstrual_day_payload(
+            symptoms=["BACKACHE", {"name": "CRAMPS", "severity": "MILD"}, None],
+            moods=["HAPPY"],
+            discharge=[],
+        )
+        file_path = tmp_path / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(payload, f)
+
+        proc = _menstrual_processor()
+        proc._process_menstrual_cycle_day(file_path, db_session)
+        db_session.commit()
+
+        tags = db_session.execute(select(MenstrualCycleTag)).scalars().all()
+        by_kind = {(t.kind, t.name) for t in tags}
+        # Dict and None are skipped; BACKACHE and HAPPY survive.
+        assert by_kind == {("SYMPTOM", "BACKACHE"), ("MOOD", "HAPPY")}
+
+
+class TestProcessMenstrualCycleSummary:
+    """
+    Tests for _process_menstrual_cycle_summary covering the wipe-and-replace policy for
+    predicted cycles alongside upsert-by-PK for observed (real) cycles.
+    """
+
+    def test_insert_observed_and_predicted(self, db_session: Session, tmp_path):
+        """
+        First-time insert populates both observed and predicted summary rows.
+        """
+        _seed_user_999(db_session)
+
+        data = {
+            "cycleSummaries": [
+                {"startDate": "2026-05-23", "periodLength": 3, "predictedCycle": False},
+                {"startDate": "2026-06-20", "periodLength": 5, "predictedCycle": True},
+                {"startDate": "2026-07-18", "periodLength": 5, "predictedCycle": True},
+            ],
+        }
+        file_path = tmp_path / "999_MENSTRUAL_CYCLE_SUMMARY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        proc = _menstrual_processor()
+        proc._process_menstrual_cycle_summary(file_path, db_session)
+        db_session.commit()
+
+        rows = (
+            db_session.execute(
+                select(MenstrualCycleSummary).order_by(MenstrualCycleSummary.start_date)
+            )
+            .scalars()
+            .all()
+        )
+        assert [str(r.start_date) for r in rows] == [
+            "2026-05-23",
+            "2026-06-20",
+            "2026-07-18",
+        ]
+        assert [r.predicted_cycle for r in rows] == [False, True, True]
+
+    def test_predictions_replaced_observed_preserved(
+        self, db_session: Session, tmp_path
+    ):
+        """
+        Critical scenario: two extract runs produce different predicted start dates.
+
+        The second run must wipe stale predictions but preserve the observed (real)
+        cycle row.
+        """
+        _seed_user_999(db_session)
+
+        # First run: 1 observed + 2 predicted.
+        first = {
+            "cycleSummaries": [
+                {"startDate": "2026-05-23", "periodLength": 3, "predictedCycle": False},
+                {"startDate": "2026-06-20", "periodLength": 5, "predictedCycle": True},
+                {"startDate": "2026-07-18", "periodLength": 5, "predictedCycle": True},
+            ],
+        }
+        file_path = tmp_path / "999_MENSTRUAL_CYCLE_SUMMARY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump(first, f)
+
+        proc = _menstrual_processor()
+        proc._process_menstrual_cycle_summary(file_path, db_session)
+        db_session.commit()
+
+        # Second run: observed cycle unchanged; Garmin recomputed projections,
+        # so the predicted start dates have shifted.
+        second = {
+            "cycleSummaries": [
+                {"startDate": "2026-05-23", "periodLength": 3, "predictedCycle": False},
+                {"startDate": "2026-06-22", "periodLength": 5, "predictedCycle": True},
+                {"startDate": "2026-07-20", "periodLength": 5, "predictedCycle": True},
+            ],
+        }
+        with open(file_path, "w") as f:
+            json.dump(second, f)
+
+        proc._process_menstrual_cycle_summary(file_path, db_session)
+        db_session.commit()
+
+        rows = (
+            db_session.execute(
+                select(MenstrualCycleSummary).order_by(MenstrualCycleSummary.start_date)
+            )
+            .scalars()
+            .all()
+        )
+        # Stale 2026-06-20 / 2026-07-18 predictions are gone; observed and new
+        # predictions remain.
+        assert [str(r.start_date) for r in rows] == [
+            "2026-05-23",
+            "2026-06-22",
+            "2026-07-20",
+        ]
+        # Observed cycle still flagged predicted=False.
+        observed = next(r for r in rows if str(r.start_date) == "2026-05-23")
+        assert observed.predicted_cycle is False
+
+    def test_empty_cycle_summaries_wipes_predictions_only(
+        self, db_session: Session, tmp_path
+    ):
+        """
+        Defensive: an empty calendar response still wipes stale predicted rows so the
+        table doesn't keep showing projections after the user clears them.
+
+        Observed cycles are unaffected (only predicted_cycle=True is in scope).
+        """
+        _seed_user_999(db_session)
+
+        # Pre-seed: 1 observed + 1 predicted.
+        db_session.add_all(
+            [
+                MenstrualCycleSummary(
+                    user_id=999,
+                    start_date=date(2026, 5, 23),
+                    period_length=3,
+                    predicted_cycle=False,
+                ),
+                MenstrualCycleSummary(
+                    user_id=999,
+                    start_date=date(2026, 6, 20),
+                    period_length=5,
+                    predicted_cycle=True,
+                ),
+            ]
+        )
+        db_session.commit()
+
+        file_path = tmp_path / "999_MENSTRUAL_CYCLE_SUMMARY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w") as f:
+            json.dump({"cycleSummaries": []}, f)
+
+        proc = _menstrual_processor()
+        proc._process_menstrual_cycle_summary(file_path, db_session)
+        db_session.commit()
+
+        rows = db_session.execute(select(MenstrualCycleSummary)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].predicted_cycle is False
+        assert str(rows[0].start_date) == "2026-05-23"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #61.

Adds two new Garmin Connect data types from the `periodic-health` service:

- **`MENSTRUAL_CYCLE_DAY`** (DAILY) — per-day log from `dayview`: phase, day-in-cycle, period length, predicted cycle length, flow, sex drive, sexual activity, freeform notes, ovulation flag, plus the symptoms / moods / discharge tags.
- **`MENSTRUAL_CYCLE_SUMMARY`** (RANGE) — per-cycle summaries from `calendar`: observed cycles and Garmin's projections. Wrapper paginates >92-day ranges into the API's max chunk size and dedupes by `startDate`.

Schema goes from 35 → 38 tables: `menstrual_cycle_day`, `menstrual_cycle_tag` (polymorphic for the three tag kinds, CASCADE-deleted via composite FK), `menstrual_cycle_summary`.

Write semantics tailored to each table's mutation profile:

- Day rows: UPSERT by `(user_id, date)`.
- Tags: delete-then-reinsert per `(user_id, date)` because users can REMOVE tags between extracts; a pure UPSERT would leave orphan rows.
- Summaries: real cycles UPSERT by `(user_id, start_date)`; predicted cycles wipe-and-replace on every extract because Garmin's projection dates shift between runs.

Bundled fix: the four `TestRefreshTokens` cases in `test_auth_extended.py` were pre-existing pollution sources, creating an empty `~/.garminconnect/12345678/` directory on every CI run. Now scoped to `tmp_path`.

## Test plan

- [x] 22 new unit tests in `test_garmin_client_api.py` and `test_processor.py` (full suite: 373 passed, 1 skipped).
- [x] End-to-end against a real account: day row + 8 tags (4 symptoms + 2 moods + 2 discharges) + 1 observed cycle + 1 predicted cycle landed correctly.
- [x] Predicted-cycle wipe-and-replace verified across two extract runs with shifting projection dates: stale prediction row is gone, current one is in.
- [x] Symptom-removal scenario: insert with `[A, B, C]`, reprocess with `[A]` → only `A` remains (delete-then-reinsert correctness).
- [x] FK cascade: deleting a `menstrual_cycle_day` row cascades to its `menstrual_cycle_tag` children.
- [x] Rogue `~/.garminconnect/12345678/` no longer reappears after running the auth test suite.
- [x] Formatters clean (`black`, `sqlfluff`).
- [x] No merge conflicts with `main`.

## Follow-ups (out of scope, filed)

- #62 — RANGE-typed extractions currently hit the API per-day instead of per-range, which makes the new calendar wrapper's pagination logic dormant in the extractor's hot path.
- #63 — Missing automated tests for `GarminClient` API delegator wiring (this PR's e2e caught a missing delegator that 372 unit tests didn't).

Privacy: `notes`, `sex_drive`, and `sexual_activity` are captured for completeness. All data stays local per existing project guarantees; the README's Privacy section now calls out the sensitivity.

openetl port deferred per discussion with the issue filer; will be tracked separately.