### PR TITLE
chore(metadata): align pyproject.toml description with new GitHub description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "garmin-health-data"
 version = "2.11.2"
-description = "Extract your Garmin Connect health data to a local SQLite database"
+description = "Download Garmin Connect health data as local files and load it into a SQLite database for analysis"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Aligns the PyPI short description (`pyproject.toml`'s `description` field) with the just-updated GitHub repo description. PyPI's short description is baked into each published distribution at upload time, so the new wording will go live whenever the next 2.x release is published to PyPI.

**Old**: `"Extract your Garmin Connect health data to a local SQLite database"`
**New**: `"Download Garmin Connect health data as local files and load it into a SQLite database for analysis"`

The new wording surfaces the dual output (local files in `garmin_files/storage/` + the SQLite DB) that the README's intro and the GitHub description already convey.

PyPI's long description (the body below the header) is sourced from `README.md` and re-uploaded with every release, so it already tracks README changes automatically — only the short description needed an explicit `pyproject.toml` edit.

## Notes

- **No behavior change. Pure metadata.** No CHANGELOG entry; this is a packaging-only tweak that doesn't warrant a user-visible release-notes line.
- **No version bump** in this PR — bump when the next substantive change lands and the two ship together. (If you'd rather cut a standalone 2.11.3 just for this, say the word and I'll add the bump + a short CHANGELOG line.)
- Parked, ready to merge whenever convenient. Can be bundled into the next real PR via rebase, or merged standalone and combined at release time.

## Test plan

- [x] No code touched, no tests needed. CI's lint + test matrix will still run as a sanity check.