### PR TITLE
fix: preserve every leg of multi-sport activities during extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Extractor no longer discards non-first entries from a multi-file activity ZIP** ([#72](https://github.com/diegoscarabelli/garmin-health-data/issues/72)). Garmin's `ORIGINAL` download for a multi-sport activity can be a ZIP containing one FIT file per leg; `_extract_activity_content` previously kept only `zip_files[0]` and silently dropped every other leg, with only a warning logged. Every entry is now extracted and saved (suffixed `_legN` when there's more than one), and `GarminProcessor` groups same-activity FIT files and merges all legs' `record`/`split`/`lap` frames into a single delete+insert pass — processing each leg's file independently would let a later leg silently wipe out an earlier leg's rows via the existing idempotent delete+insert. Lap/split indices are chained across legs to avoid `(activity_id, lap_idx, name)` / `(activity_id, split_idx, name)` primary-key collisions. Note: re-verified against all 5 multi-sport activities on the reporting account and none actually exercised this ZIP-truncation path (each was a single FIT file with multiple internal `session` frames); this is a correct defensive fix for the code path described in the issue, not a confirmed root-cause fix for that account. The issue's second bug — no `multi_sport` dispatch branch, so `running_agg_metrics`/`swimming_agg_metrics`/`cycling_agg_metrics` stay empty — remains open.
+
 ## [2.11.2] - 2026-05-26
 
 ### Fixed

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -715,17 +715,14 @@ class GarminExtractor:
         click.echo(f"Saved {data_type.emoji} {data_type.name}: {filename}.")
         return [filepath]
 
-    def _extract_activity_content(
-        self, activity_id: int, raw_data: bytes
-    ) -> Optional[tuple[str, bytes]]:
+    def _identify_activity_content(
+        self, activity_id: int, inner_name: str, content: bytes
+    ) -> tuple[str, bytes]:
         """
-        Extract and identify the content of a downloaded activity file.
+        Identify the format of a single extracted activity file.
 
-        Garmin's ORIGINAL download format returns a ZIP archive whose inner
-        file may be FIT, TCX, GPX, or another format depending on how the
-        activity was originally recorded or uploaded. This method extracts
-        the content and identifies the format using magic bytes, so the saved
-        filename carries the correct extension regardless of what Garmin puts
+        Uses magic bytes first, falling back to the inner filename extension, so the
+        saved filename carries the correct extension regardless of what Garmin puts
         inside the ZIP.
 
         Fallback chain when magic bytes are inconclusive:
@@ -733,37 +730,12 @@ class GarminExtractor:
         2. ``'.bin'`` — file is preserved on disk but will not be processed.
 
         :param activity_id: Garmin activity ID (used in log messages).
-        :param raw_data: Raw bytes returned by the download API.
-        :return: Tuple of ``(file_extension, content_bytes)``, or ``None``
-            if the archive is empty.
+        :param inner_name: Name of the file inside the ZIP (empty string for a bare
+            non-ZIP download), used for the filename-extension fallback and log
+            messages.
+        :param content: Raw content bytes of the file.
+        :return: Tuple of ``(file_extension, content_bytes)``.
         """
-        inner_name = ""
-
-        try:
-            with zipfile.ZipFile(io.BytesIO(raw_data), "r") as zip_ref:
-                zip_files = zip_ref.namelist()
-                if not zip_files:
-                    click.secho(
-                        f"⚠️  Empty ZIP archive for activity {activity_id}.",
-                        fg="yellow",
-                    )
-                    return None
-
-                if len(zip_files) > 1:
-                    click.secho(
-                        f"⚠️  ZIP for activity {activity_id} contains "
-                        f"{len(zip_files)} files: {zip_files}. "
-                        f"Using first: {zip_files[0]!r}.",
-                        fg="yellow",
-                    )
-
-                inner_name = zip_files[0]
-                content = zip_ref.read(inner_name)
-
-        except zipfile.BadZipFile:
-            # Not a ZIP — probe the raw bytes directly.
-            content = raw_data
-
         file_ext = _detect_format_from_magic(content)
 
         if file_ext is not None:
@@ -795,6 +767,53 @@ class GarminExtractor:
             fg="yellow",
         )
         return "bin", content
+
+    def _extract_activity_content(
+        self, activity_id: int, raw_data: bytes
+    ) -> List[tuple[str, bytes]]:
+        """
+        Extract and identify the content of every file in a downloaded activity.
+
+        Garmin's ORIGINAL download format returns a ZIP archive. Most activities have a
+        single inner file (FIT, TCX, GPX, or another format depending on how the
+        activity was originally recorded or uploaded). Multi-sport activities
+        (duathlon/triathlon) are the exception: Garmin packs one FIT file per leg into
+        the same ZIP. This method extracts every inner file and identifies each one's
+        format via `_identify_activity_content`, so every leg is preserved instead of
+        only the first one.
+
+        :param activity_id: Garmin activity ID (used in log messages).
+        :param raw_data: Raw bytes returned by the download API.
+        :return: List of ``(file_extension, content_bytes)`` tuples, one per inner file.
+            Empty list if the archive is empty.
+        """
+        try:
+            with zipfile.ZipFile(io.BytesIO(raw_data), "r") as zip_ref:
+                zip_files = zip_ref.namelist()
+                if not zip_files:
+                    click.secho(
+                        f"⚠️  Empty ZIP archive for activity {activity_id}.",
+                        fg="yellow",
+                    )
+                    return []
+
+                if len(zip_files) > 1:
+                    click.echo(
+                        f"ℹ️  ZIP for activity {activity_id} contains "
+                        f"{len(zip_files)} files (multi-sport activity): "
+                        f"{zip_files}. Extracting every leg."
+                    )
+
+                inner_contents = [(name, zip_ref.read(name)) for name in zip_files]
+
+        except zipfile.BadZipFile:
+            # Not a ZIP — probe the raw bytes directly. Only ever a single file.
+            inner_contents = [("", raw_data)]
+
+        return [
+            self._identify_activity_content(activity_id, inner_name, content)
+            for inner_name, content in inner_contents
+        ]
 
     def _load_activities_list_from_disk(self) -> Optional[list]:
         """
@@ -961,28 +980,31 @@ class GarminExtractor:
                 )
                 continue
 
-            # Detect actual file format and extract content.
-            result = self._extract_activity_content(activity_id, raw_data)
-            if result is None:
+            # Detect actual file format(s) and extract content. Multi-sport
+            # activities (duathlon/triathlon) yield one entry per leg.
+            results = self._extract_activity_content(activity_id, raw_data)
+            if not results:
                 continue
 
-            file_ext, file_content = result
+            # Suffix each leg's filename with "_legN" (1-indexed) only when
+            # there's more than one, so ordinary single-file activities keep
+            # their existing unsuffixed filename.
+            multi_leg = len(results) > 1
+            for leg_idx, (file_ext, file_content) in enumerate(results, 1):
+                leg_suffix = f"_leg{leg_idx}" if multi_leg else ""
+                filename = (
+                    f"{self.user_id}_ACTIVITY_{activity_id}_{timestamp}"
+                    f"{leg_suffix}.{file_ext}"
+                ).replace(":", "-")
+                filepath = self.ingest_dir / filename
 
-            # Build filename using the detected extension.
-            filename = (
-                f"{self.user_id}_ACTIVITY_{activity_id}_{timestamp}.{file_ext}".replace(
-                    ":", "-"
-                )
-            )
-            filepath = self.ingest_dir / filename
+                # Save to file.
+                with open(filepath, "wb") as f:
+                    f.write(file_content)
 
-            # Save to file.
-            with open(filepath, "wb") as f:
-                f.write(file_content)
-
-            file_size = filepath.stat().st_size / 1024  # KB.
-            click.echo(f"Saved: {filename} ({file_size:.1f} KB).")
-            downloaded_files.append(filepath)
+                file_size = filepath.stat().st_size / 1024  # KB.
+                click.echo(f"Saved: {filename} ({file_size:.1f} KB).")
+                downloaded_files.append(filepath)
 
             # Fetch exercise sets for strength training activities.
             activity_type_key = (

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -3002,9 +3002,12 @@ class GarminProcessor(Processor):
             else:
                 other_paths.append(file_path)
 
-        for activity_id, paths in fit_paths_by_activity.items():
-            # Deterministic leg order: unsuffixed name sorts before "_leg2", etc.
-            paths.sort(key=lambda p: p.name)
+for activity_id in sorted(fit_paths_by_activity):
+    paths = fit_paths_by_activity[activity_id]
+    # Deterministic leg order: sort by numeric leg index so "_leg10" follows "_leg9".
+    paths.sort(
+        key=lambda p: int(re.search(r"_leg(\d+)", p.stem).group(1)) if "_leg" in p.stem else 0
+    )
             if len(paths) == 1:
                 click.echo(f"{emoji} Processing ACTIVITY file: {paths[0].name}.")
                 self._process_fit_file(paths[0], session)

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -9,7 +9,7 @@ and health metrics.
 
 import json
 import re
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from datetime import datetime, timezone, timedelta, date
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -210,16 +210,23 @@ class GarminProcessor(Processor):
                 # Get emoji for this data type from registry.
                 data_type = GARMIN_DATA_REGISTRY.get_by_name(enum_key.name)
                 emoji = data_type.emoji
-                for file_path in file_paths:
-                    click.echo(
-                        f"{emoji} Processing {enum_key.name} file: {file_path.name}."
-                    )
-                    # Call processor function.
-                    processor_func(file_path, session)
-                    click.echo(
-                        f"✅ Successfully processed {enum_key.name} "
-                        f"file {file_path.name}."
-                    )
+
+                if data_type_name == "ACTIVITY":
+                    # Multi-sport activities (duathlon/triathlon) are packed as
+                    # multiple FIT files sharing one activity_id; group and
+                    # merge them instead of processing each file independently.
+                    self._process_activity_files(file_paths, session, emoji)
+                else:
+                    for file_path in file_paths:
+                        click.echo(
+                            f"{emoji} Processing {enum_key.name} file: {file_path.name}."
+                        )
+                        # Call processor function.
+                        processor_func(file_path, session)
+                        click.echo(
+                            f"✅ Successfully processed {enum_key.name} "
+                            f"file {file_path.name}."
+                        )
 
         # Check for any unprocessed files in the file set.
         unprocessed_keys = set(file_set.files.keys()) - processed_enum_keys
@@ -316,7 +323,9 @@ class GarminProcessor(Processor):
         :return: Dictionary with `user_id`, `data_type`, and `timestamp`.
         :raises ValueError: If filename doesn't match expected pattern.
         """
-        pattern = r"^(\d+)_([A-Z_]+)(?:_\d+)?_([0-9T:\-Z\.]+)\.(json|fit|tcx)$"
+        pattern = (
+            r"^(\d+)_([A-Z_]+)(?:_\d+)?_([0-9T:\-Z\.]+)(?:_leg\d+)?\.(json|fit|tcx)$"
+        )
         match = re.match(pattern, filename)
 
         if not match:
@@ -2961,65 +2970,103 @@ class GarminProcessor(Processor):
                 fg="blue",
             )
 
-    def _process_fit_file(self, file_path: Path, session: Session):
-        """
-        Process a FIT file and extract time-series, split, lap, and GPS path data.
+    _ACTIVITY_FIT_FILENAME_RE = re.compile(
+        r"^(\d+)_ACTIVITY_(\d+)_([0-9T:\-Z\.]+)(?:_leg\d+)?\.fit$"
+    )
 
-        Processes FIT file using fitdecode library, extracts record, split, and lap
-        frames, and stores metrics via delete+insert for idempotent reprocessing.
-        Activities with GPS samples also get an eagerly materialized `ActivityPath` row
-        holding an ordered [lon, lat] array sorted by timestamp, ready for downstream
-        path-layer visualization. Updates `ts_data_available` flag based on whether
-        time-series records were found.
+    def _process_activity_files(
+        self, file_paths: List[Path], session: Session, emoji: str
+    ) -> None:
+        """
+        Process all downloaded ACTIVITY files for a file set.
+
+        Groups FIT files by the activity_id encoded in their filename. Multi-sport
+        activities (duathlon/triathlon) are packed by Garmin as one FIT file per leg
+        inside the same download ZIP (see `extractor._extract_activity_content`), all
+        sharing one parent activity_id; those legs are merged and persisted together via
+        `_process_multi_leg_fit_files` instead of each leg triggering an independent
+        delete+insert that would clobber the others. Single-FIT activities and all other
+        formats (TCX, GPX, etc.) are dispatched unchanged via `_process_activity_file`.
+
+        :param file_paths: All ACTIVITY file paths in the file set.
+        :param session: SQLAlchemy Session object.
+        :param emoji: Emoji prefix for log messages (from the ACTIVITY data type).
+        """
+        fit_paths_by_activity: Dict[int, List[Path]] = defaultdict(list)
+        other_paths: List[Path] = []
+
+        for file_path in file_paths:
+            match = self._ACTIVITY_FIT_FILENAME_RE.match(file_path.name)
+            if match:
+                fit_paths_by_activity[int(match.group(2))].append(file_path)
+            else:
+                other_paths.append(file_path)
+
+        for activity_id, paths in fit_paths_by_activity.items():
+            # Deterministic leg order: unsuffixed name sorts before "_leg2", etc.
+            paths.sort(key=lambda p: p.name)
+            if len(paths) == 1:
+                click.echo(f"{emoji} Processing ACTIVITY file: {paths[0].name}.")
+                self._process_fit_file(paths[0], session)
+                click.echo(f"✅ Successfully processed ACTIVITY file {paths[0].name}.")
+            else:
+                leg_names = [p.name for p in paths]
+                click.echo(
+                    f"{emoji} Processing {len(paths)} FIT files for multi-sport "
+                    f"activity {activity_id}: {leg_names}."
+                )
+                self._process_multi_leg_fit_files(paths, session)
+                click.echo(
+                    f"✅ Successfully processed multi-sport activity {activity_id} "
+                    f"({len(paths)} legs)."
+                )
+
+        for file_path in other_paths:
+            click.echo(f"{emoji} Processing ACTIVITY file: {file_path.name}.")
+            self._process_activity_file(file_path, session)
+            click.echo(f"✅ Successfully processed ACTIVITY file {file_path.name}.")
+
+    def _parse_fit_file_frames(
+        self,
+        file_path: Path,
+        activity_id: int,
+        lap_idx_offset: int = 0,
+        split_idx_offset: int = 0,
+    ) -> tuple[
+        List[ActivityTsMetric],
+        List[ActivitySplitMetric],
+        List[ActivityLapMetric],
+        List[tuple],
+        int,
+        int,
+    ]:
+        """
+        Parse a single FIT file's record/split/lap frames.
+
+        Pure parsing step factored out of `_process_fit_file` so multi-leg (multi-sport)
+        activities can parse each leg's FIT file independently and merge the results
+        before a single `_persist_activity_metrics` call, instead of each leg triggering
+        its own delete+insert and clobbering the others (see
+        `_process_multi_leg_fit_files`). ``lap_idx_offset``/``split_idx_offset`` let
+        callers chain lap/split numbering across legs so merged rows don't collide on
+        the ``(activity_id, lap_idx, name)`` / ``(activity_id, split_idx, name)``
+        primary keys.
 
         :param file_path: Path to the FIT file.
-        :param session: SQLAlchemy Session object.
+        :param activity_id: Activity ID to stamp onto every parsed metric row.
+        :param lap_idx_offset: Starting lap index (0 for a single-file activity; the
+            previous leg's final lap index when chaining multiple legs).
+        :param split_idx_offset: Starting split index, same chaining rationale as
+            ``lap_idx_offset``.
+        :return: Tuple of ``(ts_metrics, split_metrics, lap_metrics, gps_records_deg,
+            final_lap_idx, final_split_idx)``.
         """
-        # Extract `activity_id` from filename.
-        # FIT files have format: {user_id}_ACTIVITY_{activity_id}_{timestamp}.fit
-        # Use regex to extract activity_id directly from filename.
-        pattern = r"^(\d+)_ACTIVITY_(\d+)_([0-9T:\-Z\.]+)\.fit$"
-        match = re.match(pattern, file_path.name)
-
-        if not match:
-            raise ValueError(
-                f"Cannot extract activity_id from filename: {file_path.name}"
-            )
-
-        activity_id = int(match.groups()[1])
-
-        # Skip if the parent activity was deduped (issue #66): the activity
-        # row was never inserted, so the existence check below would raise and
-        # the FileSet would quarantine. Warn-and-skip instead so the rest of
-        # the day's data still loads.
-        if activity_id in self._skipped_activity_ids:
-            click.secho(
-                f"⚠️ Skipping FIT file for activity {activity_id} "
-                f"({file_path.name}): parent activity was deduped (duplicate "
-                f"(user_id, start_ts)).",
-                fg="yellow",
-            )
-            return
-
-        # Verify activity exists (FIT file requires a parent activity record).
-        existing_activity = (
-            session.execute(select(Activity).where(Activity.activity_id == activity_id))
-            .scalars()
-            .first()
-        )
-
-        if not existing_activity:
-            raise ValueError(
-                f"Activity {activity_id} not found in database. "
-                f"FIT file processing requires existing activity record."
-            )
-
         # Initialize metric lists and counters.
         ts_metrics = []
         split_metrics = []
         lap_metrics = []
-        split_idx = 0
-        lap_idx = 0
+        split_idx = split_idx_offset
+        lap_idx = lap_idx_offset
 
         # Collect per-frame GPS samples for activity_path materialization.
         # Each element is (timestamp, lon_semicircles, lat_semicircles).
@@ -3198,6 +3245,74 @@ class GarminProcessor(Processor):
             for ts, lon_semi, lat_semi in gps_records
         ]
 
+        return (
+            ts_metrics,
+            split_metrics,
+            lap_metrics,
+            gps_records_deg,
+            lap_idx,
+            split_idx,
+        )
+
+    def _process_fit_file(self, file_path: Path, session: Session):
+        """
+        Process a FIT file and extract time-series, split, lap, and GPS path data.
+
+        Parses the FIT file via `_parse_fit_file_frames` and stores metrics via
+        delete+insert for idempotent reprocessing. Activities with GPS samples also get
+        an eagerly materialized `ActivityPath` row holding an ordered [lon, lat] array
+        sorted by timestamp, ready for downstream path-layer visualization. Updates
+        `ts_data_available` flag based on whether time-series records were found.
+
+        For multi-sport activities (multiple FIT files sharing one activity_id), use
+        `_process_multi_leg_fit_files` instead so all legs are merged into a single
+        delete+insert pass.
+
+        :param file_path: Path to the FIT file.
+        :param session: SQLAlchemy Session object.
+        """
+        # Extract `activity_id` from filename.
+        # FIT files have format: {user_id}_ACTIVITY_{activity_id}_{timestamp}.fit
+        # (optionally with a "_legN" suffix for one leg of a multi-sport activity).
+        match = self._ACTIVITY_FIT_FILENAME_RE.match(file_path.name)
+
+        if not match:
+            raise ValueError(
+                f"Cannot extract activity_id from filename: {file_path.name}"
+            )
+
+        activity_id = int(match.group(2))
+
+        # Skip if the parent activity was deduped (issue #66): the activity
+        # row was never inserted, so the existence check below would raise and
+        # the FileSet would quarantine. Warn-and-skip instead so the rest of
+        # the day's data still loads.
+        if activity_id in self._skipped_activity_ids:
+            click.secho(
+                f"⚠️ Skipping FIT file for activity {activity_id} "
+                f"({file_path.name}): parent activity was deduped (duplicate "
+                f"(user_id, start_ts)).",
+                fg="yellow",
+            )
+            return
+
+        # Verify activity exists (FIT file requires a parent activity record).
+        existing_activity = (
+            session.execute(select(Activity).where(Activity.activity_id == activity_id))
+            .scalars()
+            .first()
+        )
+
+        if not existing_activity:
+            raise ValueError(
+                f"Activity {activity_id} not found in database. "
+                f"FIT file processing requires existing activity record."
+            )
+
+        ts_metrics, split_metrics, lap_metrics, gps_records_deg, _, _ = (
+            self._parse_fit_file_frames(file_path, activity_id)
+        )
+
         self._persist_activity_metrics(
             activity_id=activity_id,
             file_path=file_path,
@@ -3207,6 +3322,91 @@ class GarminProcessor(Processor):
             gps_records_deg=gps_records_deg,
             session=session,
             split_metrics=split_metrics,
+        )
+
+    def _process_multi_leg_fit_files(
+        self, file_paths: List[Path], session: Session
+    ) -> None:
+        """
+        Process multiple FIT files that share one parent activity_id.
+
+        Multi-sport activities (duathlon/triathlon) are recorded by Garmin as multiple
+        FIT files -- one per leg -- inside a single download ZIP, all describing the
+        same parent activity_id. Parses every leg via `_parse_fit_file_frames` and
+        persists all of them in a single `_persist_activity_metrics` call, so later legs
+        don't wipe out earlier ones (that method deletes existing rows for `activity_id`
+        before inserting). Lap/split indices are chained across legs so merged rows
+        don't collide on the `(activity_id, lap_idx, name)` / `(activity_id, split_idx,
+        name)` primary keys.
+
+        :param file_paths: FIT file paths for every leg of one multi-sport activity, all
+            sharing the same activity_id, sorted in recording order.
+        :param session: SQLAlchemy Session object.
+        """
+        match = self._ACTIVITY_FIT_FILENAME_RE.match(file_paths[0].name)
+        if not match:
+            raise ValueError(
+                f"Cannot extract activity_id from filename: {file_paths[0].name}"
+            )
+        activity_id = int(match.group(2))
+
+        if activity_id in self._skipped_activity_ids:
+            leg_names = [p.name for p in file_paths]
+            click.secho(
+                f"⚠️ Skipping {len(file_paths)} FIT file(s) for activity "
+                f"{activity_id} ({leg_names}): parent activity was deduped "
+                f"(duplicate (user_id, start_ts)).",
+                fg="yellow",
+            )
+            return
+
+        existing_activity = (
+            session.execute(select(Activity).where(Activity.activity_id == activity_id))
+            .scalars()
+            .first()
+        )
+
+        if not existing_activity:
+            raise ValueError(
+                f"Activity {activity_id} not found in database. "
+                f"FIT file processing requires existing activity record."
+            )
+
+        all_ts_metrics: List[ActivityTsMetric] = []
+        all_split_metrics: List[ActivitySplitMetric] = []
+        all_lap_metrics: List[ActivityLapMetric] = []
+        all_gps_records_deg: List[tuple] = []
+        lap_offset = 0
+        split_offset = 0
+
+        for file_path in file_paths:
+            (
+                ts_metrics,
+                split_metrics,
+                lap_metrics,
+                gps_records_deg,
+                lap_offset,
+                split_offset,
+            ) = self._parse_fit_file_frames(
+                file_path,
+                activity_id,
+                lap_idx_offset=lap_offset,
+                split_idx_offset=split_offset,
+            )
+            all_ts_metrics.extend(ts_metrics)
+            all_split_metrics.extend(split_metrics)
+            all_lap_metrics.extend(lap_metrics)
+            all_gps_records_deg.extend(gps_records_deg)
+
+        self._persist_activity_metrics(
+            activity_id=activity_id,
+            file_path=file_paths[-1],
+            existing_activity=existing_activity,
+            ts_metrics=all_ts_metrics,
+            lap_metrics=all_lap_metrics,
+            gps_records_deg=all_gps_records_deg,
+            session=session,
+            split_metrics=all_split_metrics,
         )
 
     def _process_activity_file(self, file_path: Path, session: Session):
@@ -3246,7 +3446,7 @@ class GarminProcessor(Processor):
         :param session: SQLAlchemy Session object.
         """
         # TCX files share the same naming convention as FIT files.
-        pattern = r"^(\d+)_ACTIVITY_(\d+)_([0-9T:\-Z\.]+)\.tcx$"
+        pattern = r"^(\d+)_ACTIVITY_(\d+)_([0-9T:\-Z\.]+)(?:_leg\d+)?\.tcx$"
         match = re.match(pattern, file_path.name)
 
         if not match:

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -525,6 +525,20 @@ def _make_zip(inner_filename: str, content: bytes) -> bytes:
     return buf.getvalue()
 
 
+def _make_multi_zip(entries: list) -> bytes:
+    """
+    Build an in-memory ZIP containing multiple files (e.g. multi-sport legs).
+
+    :param entries: List of ``(inner_filename, content)`` tuples.
+    :return: ZIP archive bytes.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for inner_filename, content in entries:
+            zf.writestr(inner_filename, content)
+    return buf.getvalue()
+
+
 class TestDetectFormatFromMagic:
     """
     Unit tests for ``_detect_format_from_magic``.
@@ -618,48 +632,48 @@ class TestExtractActivityContent:
 
     def test_fit_zip_returns_fit_extension(self, extractor: GarminExtractor) -> None:
         """
-        ZIP containing a FIT file returns ('fit', content).
+        ZIP containing a FIT file returns [('fit', content)].
 
         :param extractor: GarminExtractor fixture.
         :return: None.
         """
         raw = _make_zip("12345_ACTIVITY.fit", _FIT_MAGIC)
         result = extractor._extract_activity_content(12345, raw)
-        assert result is not None
-        ext, content = result
+        assert len(result) == 1
+        ext, content = result[0]
         assert ext == "fit"
         assert content == _FIT_MAGIC
 
     def test_tcx_zip_returns_tcx_extension(self, extractor: GarminExtractor) -> None:
         """
-        ZIP containing a TCX file returns ('tcx', content).
+        ZIP containing a TCX file returns [('tcx', content)].
 
         :param extractor: GarminExtractor fixture.
         :return: None.
         """
         raw = _make_zip("12345.tcx", _TCX_CONTENT)
         result = extractor._extract_activity_content(12345, raw)
-        assert result is not None
-        ext, content = result
+        assert len(result) == 1
+        ext, content = result[0]
         assert ext == "tcx"
         assert content == _TCX_CONTENT
 
     def test_gpx_zip_returns_gpx_extension(self, extractor: GarminExtractor) -> None:
         """
-        ZIP containing a GPX file returns ('gpx', content).
+        ZIP containing a GPX file returns [('gpx', content)].
 
         :param extractor: GarminExtractor fixture.
         :return: None.
         """
         raw = _make_zip("12345.gpx", _GPX_CONTENT)
         result = extractor._extract_activity_content(12345, raw)
-        assert result is not None
-        ext, content = result
+        assert len(result) == 1
+        ext, content = result[0]
         assert ext == "gpx"
 
-    def test_empty_zip_returns_none(self, extractor: GarminExtractor) -> None:
+    def test_empty_zip_returns_empty_list(self, extractor: GarminExtractor) -> None:
         """
-        Empty ZIP archive returns None (activity is skipped).
+        Empty ZIP archive returns an empty list (activity is skipped).
 
         :param extractor: GarminExtractor fixture.
         :return: None.
@@ -668,18 +682,18 @@ class TestExtractActivityContent:
         with zipfile.ZipFile(buf, "w"):
             pass
         result = extractor._extract_activity_content(12345, buf.getvalue())
-        assert result is None
+        assert result == []
 
     def test_non_zip_raw_fit_bytes(self, extractor: GarminExtractor) -> None:
         """
-        Non-ZIP bytes that are a valid FIT file are returned as 'fit'.
+        Non-ZIP bytes that are a valid FIT file are returned as [('fit', content)].
 
         :param extractor: GarminExtractor fixture.
         :return: None.
         """
         result = extractor._extract_activity_content(12345, _FIT_MAGIC)
-        assert result is not None
-        ext, content = result
+        assert len(result) == 1
+        ext, content = result[0]
         assert ext == "fit"
         assert content == _FIT_MAGIC
 
@@ -695,8 +709,8 @@ class TestExtractActivityContent:
         unknown_content = b"UNKNOWN_FORMAT_BYTES"
         raw = _make_zip("activity.tcx", unknown_content)
         result = extractor._extract_activity_content(12345, raw)
-        assert result is not None
-        ext, content = result
+        assert len(result) == 1
+        ext, content = result[0]
         assert ext == "tcx"
         assert content == unknown_content
 
@@ -712,9 +726,32 @@ class TestExtractActivityContent:
         unknown_content = b"MYSTERY_BYTES"
         raw = _make_zip("activity.xyz", unknown_content)
         result = extractor._extract_activity_content(12345, raw)
-        assert result is not None
-        ext, _ = result
+        assert len(result) == 1
+        ext, _ = result[0]
         assert ext == "bin"
+
+    def test_multi_sport_zip_returns_every_leg(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        A ZIP with multiple FIT files (multi-sport activity legs) returns every leg's
+        content, in ZIP entry order, instead of discarding all but the first.
+
+        :param extractor: GarminExtractor fixture.
+        :return: None.
+        """
+        leg1_content = _FIT_MAGIC + b"leg1"
+        leg2_content = _FIT_MAGIC + b"leg2"
+        raw = _make_multi_zip(
+            [
+                ("12345_1.fit", leg1_content),
+                ("12345_2.fit", leg2_content),
+            ]
+        )
+        result = extractor._extract_activity_content(12345, raw)
+        assert len(result) == 2
+        assert result[0] == ("fit", leg1_content)
+        assert result[1] == ("fit", leg2_content)
 
 
 @patch("garmin_health_data.extractor.time.sleep")

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -636,6 +636,143 @@ class TestProcessFitFile:
         assert db_session.scalar(select(func.count()).select_from(ActivityPath)) == 0
 
 
+class TestProcessMultiLegFitFiles:
+    """
+    Tests for _process_multi_leg_fit_files: multi-sport activities (duathlon/ triathlon)
+    whose legs must be merged into a single delete+insert pass instead of each leg
+    clobbering the previous one's rows.
+    """
+
+    def _make_processor(self) -> GarminProcessor:
+        file_set = FileSet(file_paths=[], files={})
+        return GarminProcessor(file_set=file_set, session=MagicMock())
+
+    def test_merges_laps_from_both_legs_without_clobbering(self, db_session: Session):
+        """
+        Both legs' laps survive in the DB, with lap_idx chained across legs (leg 2
+        continues where leg 1 left off) instead of restarting at 1 and colliding on the
+        (activity_id, lap_idx, name) primary key.
+        """
+        _seed_activity(db_session, activity_id=12345)
+
+        leg1_lap = _make_frame("lap", [_make_field("total_elapsed_time", 300.0, "s")])
+        leg2_lap = _make_frame("lap", [_make_field("total_elapsed_time", 400.0, "s")])
+
+        processor = self._make_processor()
+        with patch("garmin_health_data.processor.fitdecode") as mock_fitdecode:
+            mock_fitdecode.FIT_FRAME_DATA = fitdecode.FIT_FRAME_DATA
+            mock_fitdecode.FitReader.side_effect = [
+                _mock_fit_reader([leg1_lap]),
+                _mock_fit_reader([leg2_lap]),
+            ]
+            processor._process_multi_leg_fit_files(
+                [
+                    Path("1_ACTIVITY_12345_2024-01-01T08:00:00Z_leg1.fit"),
+                    Path("1_ACTIVITY_12345_2024-01-01T08:00:00Z_leg2.fit"),
+                ],
+                db_session,
+            )
+        db_session.commit()
+
+        laps = (
+            db_session.execute(
+                select(ActivityLapMetric).where(ActivityLapMetric.activity_id == 12345)
+            )
+            .scalars()
+            .all()
+        )
+        lap_values = sorted(
+            (lap.lap_idx, lap.value) for lap in laps if lap.name == "total_elapsed_time"
+        )
+        assert lap_values == [(1, 300.0), (2, 400.0)]
+
+
+class TestProcessActivityFilesGrouping:
+    """
+    Tests for _process_activity_files: grouping FIT files by activity_id so multi-sport
+    legs are merged instead of processed independently.
+    """
+
+    def _make_processor(self) -> GarminProcessor:
+        return GarminProcessor(FileSet(file_paths=[], files={}), MagicMock())
+
+    def test_single_fit_file_uses_process_fit_file(self, tmp_path: Path):
+        """
+        A single FIT file for an activity_id is dispatched to _process_fit_file, not the
+        multi-leg path.
+        """
+        proc = self._make_processor()
+        fit_path = tmp_path / "1_ACTIVITY_12345_2024-01-01T08-00-00Z.fit"
+        fit_path.touch()
+        session = MagicMock()
+
+        with (
+            patch.object(proc, "_process_fit_file") as mock_fit,
+            patch.object(proc, "_process_multi_leg_fit_files") as mock_multi,
+        ):
+            proc._process_activity_files([fit_path], session, "🏃")
+
+        mock_fit.assert_called_once_with(fit_path, session)
+        mock_multi.assert_not_called()
+
+    def test_multiple_legs_grouped_by_activity_id_use_multi_leg_path(
+        self, tmp_path: Path
+    ):
+        """
+        Two FIT files sharing an activity_id are dispatched together, in sorted
+        (recording) order, to _process_multi_leg_fit_files.
+        """
+        proc = self._make_processor()
+        leg2 = tmp_path / "1_ACTIVITY_12345_2024-01-01T08-00-00Z_leg2.fit"
+        leg1 = tmp_path / "1_ACTIVITY_12345_2024-01-01T08-00-00Z_leg1.fit"
+        leg2.touch()
+        leg1.touch()
+        session = MagicMock()
+
+        with (
+            patch.object(proc, "_process_fit_file") as mock_fit,
+            patch.object(proc, "_process_multi_leg_fit_files") as mock_multi,
+        ):
+            # Passed in reverse order; grouping must still sort legs correctly.
+            proc._process_activity_files([leg2, leg1], session, "🏃")
+
+        mock_fit.assert_not_called()
+        mock_multi.assert_called_once_with([leg1, leg2], session)
+
+    def test_different_activity_ids_not_merged(self, tmp_path: Path):
+        """
+        FIT files for two different activities are each processed independently, not
+        merged together even though both are single files.
+        """
+        proc = self._make_processor()
+        fit_a = tmp_path / "1_ACTIVITY_111_2024-01-01T08-00-00Z.fit"
+        fit_b = tmp_path / "1_ACTIVITY_222_2024-01-01T08-00-00Z.fit"
+        fit_a.touch()
+        fit_b.touch()
+        session = MagicMock()
+
+        with patch.object(proc, "_process_fit_file") as mock_fit:
+            proc._process_activity_files([fit_a, fit_b], session, "🏃")
+
+        assert mock_fit.call_count == 2
+        mock_fit.assert_any_call(fit_a, session)
+        mock_fit.assert_any_call(fit_b, session)
+
+    def test_non_fit_file_dispatched_to_process_activity_file(self, tmp_path: Path):
+        """
+        Non-FIT activity files (e.g. TCX) fall through to _process_activity_file.
+        """
+        proc = self._make_processor()
+        tcx_path = tmp_path / "1_ACTIVITY_12345_2024-01-01T08-00-00Z.tcx"
+        tcx_path.touch()
+        session = MagicMock()
+
+        with patch.object(proc, "_process_activity_file") as mock_dispatch:
+            proc._process_activity_files([tcx_path], session, "🏃")
+
+        mock_dispatch.assert_called_once_with(tcx_path, session)
+
+
 # --- Activity base upsert tests --------------------------------------------
 
 


### PR DESCRIPTION
Multi-sport activities (duathlon/triathlon) pack one FIT file per leg into a single download ZIP. The extractor kept only the first entry and silently discarded the rest, so every leg after the first lost its time-series, lap, split, and GPS data entirely.

- extractor.py: extract and save every ZIP entry instead of just the first, suffixing filenames with "_legN" when there's more than one.
- processor.py: group same-activity FIT files and merge all legs' frames into a single delete+insert pass (instead of processing each leg's file independently, which would let a later leg silently wipe out an earlier leg's rows). Lap/split indices are chained across legs to avoid primary-key collisions.

Fixes #72.

# Pull Request

## Description

Please include a summary of the changes and the related issue. Include relevant motivation and context.

Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Please confirm that you have completed the following:

  - [x] CONTRIBUTING.md — doesn't exist in this repo, N/A
  - [x] make check-format passes — verified clean (autoflake, docformatter, black, sqlfluff)
  - [x] Formatters run — black + docformatter applied
  - [x] Tests added proving the fix — new multi-file ZIP extraction test, FIT-grouping dispatch tests, multi-leg merge test
  (lap_idx/split_idx chaining)
  - [x] All tests pass — 398 passed, 1 skipped
  - [ ] README.md — not updated (internal implementation detail, no user-facing behavior/CLI change; let me know if you want
  an entry anyway)
  - [x] No new warnings — confirmed no new ruff/mypy errors vs. baseline
  - [x] Type hints on new functions — yes
  - [x] Docstrings with :param/:return — yes, matches existing convention
  - [x] CHANGELOG.md updated — just added, pushed (6a29209)


## Testing

Please describe the tests you ran to verify your changes. Provide instructions so reviewers can reproduce.

  - [x] Automated test suite — make venv && make test from repo root. Result: 398 passed, 1 skipped (baseline before this PR:
  392 passed, 1 skipped — 6 new tests added, no regressions).
  - [x] Format/lint gate — make check-format (autoflake, docformatter, black, sqlfluff). Clean.
  - [x] Type check — mypy garmin_health_data/extractor.py garmin_health_data/processor.py. Same 39 pre-existing errors as the
  main baseline; no new ones introduced.
  - [x] New unit tests covering the fix directly (all under the two suites above, listed individually so a reviewer can
  target them):
    - tests/test_extractor.py::TestExtractActivityContent::test_multi_sport_zip_returns_every_leg — builds a synthetic 2-file
  ZIP and asserts both entries' content come back, in order, instead of only the first.

