### PR TITLE
fix(body-composition): capture every weigh-in on multi-weigh-in days (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`BODY_COMPOSITION` now captures every weigh-in on days with more than one** ([#69](https://github.com/diegoscarabelli/garmin-health-data/issues/69)). Extraction hit `/weight-service/weight/daterangesnapshot`, the endpoint behind Garmin Connect's weight *trend chart*, which returns only one representative weigh-in per calendar day. Users who weigh more than once a day (e.g. morning and evening) silently lost all but one weigh-in at the API boundary, regardless of the `(user_id, timestamp)` primary key on `body_composition` that was meant to hold multiple. This predates the per-day split in [#65](https://github.com/diegoscarabelli/garmin-health-data/pull/65): the endpoint was `daterangesnapshot` from the feature's introduction in [#49](https://github.com/diegoscarabelli/garmin-health-data/pull/49), and #65 only changed the call cadence (day-by-day → one range call + split), not the endpoint, so the "multiple weigh-ins per day are preserved" claim was never actually true end-to-end. Extraction now uses `/weight-service/weight/range/{start}/{end}` with `includeAll=true`, which returns every weigh-in grouped under `dailyWeightSummaries[].allWeightMetrics`. The per-day file splitter reads that shape and groups by Garmin's own `summaryDate` (the user-facing local day) rather than each weigh-in's UTC `timestampGMT`, so two weigh-ins on the same local day land in one per-day file even when their UTC timestamps straddle midnight (matching how the `ACTIVITIES_LIST` splitter groups by local date). Still one API call per window (the #65 optimization is preserved), and the per-day file shape at the processor boundary is unchanged (`allWeightMetrics` entries carry the same field names the processor already reads), so `_process_body_composition` is untouched. Verified end-to-end on a real account: a day with a morning and an evening weigh-in now writes two `body_composition` rows instead of one.
+
 ## [2.11.2] - 2026-05-26
 
 ### Fixed

--- a/garmin_health_data/constants.py
+++ b/garmin_health_data/constants.py
@@ -175,7 +175,7 @@ class GarminDataRegistry:
                 "BODY_COMPOSITION",
                 "get_body_composition",
                 APIMethodTimeParam.RANGE,
-                "/weight-service/weight/daterangesnapshot",
+                "/weight-service/weight/range/{start}/{end}",
                 "Scale weigh-ins: weight, BMI, body fat %, body water %, bone mass, "
                 "muscle mass, physique rating, visceral fat, metabolic age. Multiple "
                 "entries per day if the user weighs more than once.",

--- a/garmin_health_data/constants.py
+++ b/garmin_health_data/constants.py
@@ -175,7 +175,7 @@ class GarminDataRegistry:
                 "BODY_COMPOSITION",
                 "get_body_composition",
                 APIMethodTimeParam.RANGE,
-                "/weight-service/weight/range/{start}/{end}",
+                "/weight-service/weight/range/{start}/{end}?includeAll=true",
                 "Scale weigh-ins: weight, BMI, body fat %, body water %, bone mass, "
                 "muscle mass, physique rating, visceral fat, metabolic age. Multiple "
                 "entries per day if the user weighs more than once.",

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -13,7 +13,7 @@ import zipfile
 import io
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, date, timezone
+from datetime import datetime, timedelta, date
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -124,46 +124,43 @@ def _split_body_composition_by_day(
     """
     Split a ``BODY_COMPOSITION`` per-range response into per-day payloads.
 
-    Each entry in ``dateWeightList`` carries its own ``timestampGMT`` (milliseconds
-    since epoch). Groups entries by their UTC calendar date. Days without entries
-    yield no key in the returned dict. The per-day payload preserves the
-    ``dateWeightList`` wrapper key so the downstream body-composition processor
-    parses it identically to the legacy per-day API responses. The other
-    range-level wrapper fields (``startDate``, ``endDate``, ``totalAverage``) are
-    intentionally dropped: they describe the full range and are not consumed by
-    the processor.
+    The range endpoint (``/weight-service/weight/range/{start}/{end}?includeAll=true``)
+    returns one ``dailyWeightSummaries`` entry per local calendar day that has data. Each
+    summary carries *every* weigh-in for that day under ``allWeightMetrics`` (a user may
+    weigh more than once per day) and the user-facing local day under ``summaryDate``.
 
-    Malformed entries (no usable timestamp) are silently dropped: they cannot be
-    grouped into any day's bucket and they never reach the processor (the splitter
-    is the only place such an entry can be skipped, so any downstream warning would
-    never fire). Real-world responses haven't shown this shape in practice; the
-    guard is defensive.
+    Groups by Garmin's own ``summaryDate`` rather than by each weigh-in's UTC
+    ``timestampGMT`` so that two weigh-ins on the same local day land in one per-day file
+    even when their UTC timestamps straddle midnight (e.g. a late-evening weigh-in in a
+    timezone behind UTC). This mirrors the ``ACTIVITIES_LIST`` splitter, which groups by
+    the user's local date for the same reason. Each per-day payload is re-wrapped under
+    the ``dateWeightList`` key so the downstream body-composition processor parses it
+    identically to the legacy per-day API responses; the ``allWeightMetrics`` entries
+    carry the same field names (``timestampGMT``, ``weight``, ``bmi``, ...) the processor
+    reads. The range-level wrapper fields (``totalAverage``, ``previousDateWeight``,
+    ``nextDateWeight``) are intentionally dropped: they describe the full range and are
+    not consumed by the processor.
+
+    Summaries with no weigh-ins or an unparseable ``summaryDate`` are skipped: they
+    cannot anchor a per-day file and they never reach the processor.
 
     :param payload: Full range response from ``get_body_composition``.
-    :return: Mapping ``{date: {"dateWeightList": [...that day's entries...]}}``.
+    :return: Mapping ``{date: {"dateWeightList": [...that day's weigh-ins...]}}``.
     """
     by_day: Dict[date, List[Dict[str, Any]]] = {}
-    for entry in payload.get("dateWeightList") or []:
-        # Use `is not None` rather than truthiness so a valid epoch-zero
-        # timestamp (Unix Jan 1 1970) wouldn't be silently treated as missing
-        # and replaced by the `date` fallback. Realistically Garmin will never
-        # return that, but the explicit check matches the dropped-entry
-        # docstring contract.
-        ts_ms = entry.get("timestampGMT")
-        if ts_ms is None:
-            ts_ms = entry.get("date")
-        if ts_ms is None:
+    for summary in payload.get("dailyWeightSummaries") or []:
+        metrics = summary.get("allWeightMetrics") or []
+        if not metrics:
+            continue
+        summary_date = summary.get("summaryDate")
+        if not isinstance(summary_date, str):
             continue
         try:
-            entry_date = datetime.fromtimestamp(
-                int(ts_ms) / 1000, tz=timezone.utc
-            ).date()
-        except (TypeError, ValueError, OverflowError, OSError):
-            # Non-numeric, out-of-range, or otherwise unconvertible timestamp.
-            # Drop the entry rather than abort the whole RANGE extraction; matches
-            # the docstring's "malformed entries are silently dropped" contract.
+            # ``summaryDate`` is the local calendar day as ``YYYY-MM-DD``.
+            day = date.fromisoformat(summary_date[:10])
+        except ValueError:
             continue
-        by_day.setdefault(entry_date, []).append(entry)
+        by_day.setdefault(day, []).extend(metrics)
     return {d: {"dateWeightList": entries} for d, entries in by_day.items()}
 
 
@@ -524,8 +521,8 @@ class GarminExtractor:
         self, data_type: GarminDataType, start_date: date, end_date: date
     ) -> List[Path]:
         """
-        Extract a RANGE-typed Garmin data type with a single API call covering the
-        full window, instead of one call per day.
+        Extract a RANGE-typed Garmin data type with a single API call covering the full
+        window, instead of one call per day.
 
         The Garmin endpoints behind RANGE-typed wrappers each accept a native date
         range and return all matching rows in one response (the wrappers paginate

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -141,16 +141,22 @@ def _split_body_composition_by_day(
     ``nextDateWeight``) are intentionally dropped: they describe the full range and are
     not consumed by the processor.
 
-    Summaries with no weigh-ins or an unparseable ``summaryDate`` are skipped: they
-    cannot anchor a per-day file and they never reach the processor.
+    Malformed summaries are skipped rather than aborting the whole range split: a
+    non-dict summary, a non-list or empty ``allWeightMetrics``, or an unparseable
+    ``summaryDate`` cannot anchor a per-day file and never reaches the processor.
 
     :param payload: Full range response from ``get_body_composition``.
     :return: Mapping ``{date: {"dateWeightList": [...that day's weigh-ins...]}}``.
     """
     by_day: Dict[date, List[Dict[str, Any]]] = {}
     for summary in payload.get("dailyWeightSummaries") or []:
-        metrics = summary.get("allWeightMetrics") or []
-        if not metrics:
+        # Type-guard each summary so a single malformed entry (non-dict summary,
+        # or ``allWeightMetrics`` that isn't a list) is skipped rather than
+        # aborting the whole range split, per the "skipped" contract above.
+        if not isinstance(summary, dict):
+            continue
+        metrics = summary.get("allWeightMetrics")
+        if not isinstance(metrics, list) or not metrics:
             continue
         summary_date = summary.get("summaryDate")
         if not isinstance(summary_date, str):

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -142,8 +142,10 @@ def _split_body_composition_by_day(
     not consumed by the processor.
 
     Malformed summaries are skipped rather than aborting the whole range split: a
-    non-dict summary, a non-list or empty ``allWeightMetrics``, or an unparseable
+    non-dict summary, a non-list ``allWeightMetrics``, or an unparseable
     ``summaryDate`` cannot anchor a per-day file and never reaches the processor.
+    Non-dict weigh-in entries within a summary are filtered out (the processor reads
+    each via ``entry.get(...)``); a summary is skipped once no usable entries remain.
 
     :param payload: Full range response from ``get_body_composition``.
     :return: Mapping ``{date: {"dateWeightList": [...that day's weigh-ins...]}}``.
@@ -156,7 +158,13 @@ def _split_body_composition_by_day(
         if not isinstance(summary, dict):
             continue
         metrics = summary.get("allWeightMetrics")
-        if not isinstance(metrics, list) or not metrics:
+        if not isinstance(metrics, list):
+            continue
+        # Keep only dict weigh-in entries; the processor reads each via
+        # ``entry.get(...)`` and a non-dict element (None, str) would crash it and
+        # quarantine the whole FileSet. Skip the summary if nothing usable remains.
+        metrics = [m for m in metrics if isinstance(m, dict)]
+        if not metrics:
             continue
         summary_date = summary.get("summaryDate")
         if not isinstance(summary_date, str):

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -118,6 +118,23 @@ class ExtractionFailure:
     error: str
 
 
+def _weighin_has_numeric_timestamp(entry: Dict[str, Any]) -> bool:
+    """
+    Report whether a weigh-in entry has a numeric epoch-ms timestamp.
+
+    Mirrors how ``_process_body_composition`` reads the timestamp (``timestampGMT``
+    falling back to ``date``) and does arithmetic on it (``ts_ms / 1000``). An entry
+    this rejects is exactly one the processor would crash on (TypeError / OverflowError
+    / OSError), quarantining the whole per-day FileSet. ``bool`` is excluded because it
+    is an ``int`` subclass but never a real timestamp.
+
+    :param entry: A single ``allWeightMetrics`` weigh-in dict.
+    :return:``True`` if the timestamp is a usable ``int``/``float``.
+    """
+    ts = entry.get("timestampGMT") or entry.get("date")
+    return isinstance(ts, (int, float)) and not isinstance(ts, bool)
+
+
 def _split_body_composition_by_day(
     payload: Dict[str, Any],
 ) -> Dict[date, Dict[str, Any]]:
@@ -144,8 +161,9 @@ def _split_body_composition_by_day(
     Malformed summaries are skipped rather than aborting the whole range split: a
     non-dict summary, a non-list ``allWeightMetrics``, or an unparseable
     ``summaryDate`` cannot anchor a per-day file and never reaches the processor.
-    Non-dict weigh-in entries within a summary are filtered out (the processor reads
-    each via ``entry.get(...)``); a summary is skipped once no usable entries remain.
+    Weigh-in entries that are non-dict or lack a numeric timestamp are filtered out
+    (the processor reads each via ``entry.get(...)`` and divides the timestamp); a
+    summary is skipped once no usable entries remain.
 
     :param payload: Full range response from ``get_body_composition``.
     :return: Mapping ``{date: {"dateWeightList": [...that day's weigh-ins...]}}``.
@@ -160,10 +178,15 @@ def _split_body_composition_by_day(
         metrics = summary.get("allWeightMetrics")
         if not isinstance(metrics, list):
             continue
-        # Keep only dict weigh-in entries; the processor reads each via
-        # ``entry.get(...)`` and a non-dict element (None, str) would crash it and
-        # quarantine the whole FileSet. Skip the summary if nothing usable remains.
-        metrics = [m for m in metrics if isinstance(m, dict)]
+        # Keep only dict weigh-in entries with a numeric timestamp: the processor
+        # reads each via ``entry.get(...)`` and divides the timestamp, so a non-dict
+        # element or a missing/non-numeric timestamp would crash it and quarantine the
+        # whole FileSet. Skip the summary if nothing usable remains.
+        metrics = [
+            m
+            for m in metrics
+            if isinstance(m, dict) and _weighin_has_numeric_timestamp(m)
+        ]
         if not metrics:
             continue
         summary_date = summary.get("summaryDate")

--- a/garmin_health_data/garmin_client/api.py
+++ b/garmin_health_data/garmin_client/api.py
@@ -48,7 +48,7 @@ from .constants import (
     TRAINING_STATUS_URL,
     USER_SETTINGS_URL,
     USER_SUMMARY_CHART_URL,
-    WEIGHT_DATERANGE_URL,
+    WEIGHT_RANGE_URL,
 )
 
 if TYPE_CHECKING:
@@ -275,30 +275,37 @@ def get_body_composition(
     """
     Fetch scale weigh-ins (weight and body composition) for a date range.
 
-    Each entry in ``dateWeightList`` corresponds to a single weigh-in. A user may weigh
-    more than once per day, in which case the API returns multiple entries.
+    Uses the ``/weight-service/weight/range/{start}/{end}`` endpoint with
+    ``includeAll=true``, which returns *every* weigh-in per day grouped under
+    ``dailyWeightSummaries`` (one entry per local calendar day; each carries its day's
+    weigh-ins in ``allWeightMetrics`` and the local day in ``summaryDate``). A user may
+    weigh more than once per day, in which case ``allWeightMetrics`` holds multiple
+    entries. The previously used ``daterangesnapshot`` endpoint returned only one
+    representative weigh-in per day, silently dropping the rest (see #69).
 
-    On days with no weigh-in the Garmin endpoint returns a populated wrapper dict
-    (``startDate``, ``endDate``, an empty ``dateWeightList``, and a ``totalAverage`` of
-    nulls) rather than an empty response. This function normalizes that shape to
-    ``None`` so the extractor's ``if data:`` truthiness check skips the file write,
-    matching the behavior of other RANGE-typed endpoints (e.g. ``ACTIVITIES_LIST``).
+    On ranges with no weigh-in the Garmin endpoint returns a populated wrapper dict (an
+    empty ``dailyWeightSummaries`` plus ``totalAverage`` / ``previousDateWeight`` /
+    ``nextDateWeight`` of nulls) rather than an empty response. This function normalizes
+    that shape to ``None`` so the extractor's ``if data:`` truthiness check skips the
+    file write, matching the behavior of other RANGE-typed endpoints (e.g.
+    ``ACTIVITIES_LIST``).
 
     :param client: GarminClient instance.
     :param startdate: Start date in ``YYYY-MM-DD`` format.
     :param enddate: Optional end date in ``YYYY-MM-DD`` format. Defaults to
         ``startdate``.
-    :return: Snapshot dictionary with ``dateWeightList`` (one entry per weigh-in) and
-        ``totalAverage`` aggregates, or ``None`` if no weigh-ins were recorded.
+    :return: Dictionary with ``dailyWeightSummaries`` (one entry per day, each with an
+        ``allWeightMetrics`` list of weigh-ins), or ``None`` if no weigh-ins were
+        recorded.
     """
     startdate = _validate_date_format(startdate, "startdate")
     if enddate is None:
         enddate = startdate
     else:
         enddate = _validate_date_format(enddate, "enddate")
-    params = {"startDate": startdate, "endDate": enddate}
-    result = client._connectapi(WEIGHT_DATERANGE_URL, params=params)
-    if result and result.get("dateWeightList"):
+    url = f"{WEIGHT_RANGE_URL}/{startdate}/{enddate}"
+    result = client._connectapi(url, params={"includeAll": True})
+    if result and result.get("dailyWeightSummaries"):
         return result
     return None
 

--- a/garmin_health_data/garmin_client/api.py
+++ b/garmin_health_data/garmin_client/api.py
@@ -304,7 +304,10 @@ def get_body_composition(
     else:
         enddate = _validate_date_format(enddate, "enddate")
     url = f"{WEIGHT_RANGE_URL}/{startdate}/{enddate}"
-    result = client._connectapi(url, params={"includeAll": True})
+    # Send the literal lowercase string so the wire format matches the documented
+    # ``includeAll=true`` param; ``requests`` would serialize a Python bool as
+    # ``includeAll=True`` (capitalized), relying on Garmin's case-insensitive parsing.
+    result = client._connectapi(url, params={"includeAll": "true"})
     if result and result.get("dailyWeightSummaries"):
         return result
     return None

--- a/garmin_health_data/garmin_client/constants.py
+++ b/garmin_health_data/garmin_client/constants.py
@@ -111,8 +111,10 @@ USER_SUMMARY_CHART_URL = "/wellness-service/wellness/dailySummaryChart"
 FLOORS_CHART_DAILY_URL = "/wellness-service/wellness/floorsChartData/daily"
 DAILY_INTENSITY_MINUTES_URL = "/wellness-service/wellness/daily/im"
 
-# Weight / body composition.
-WEIGHT_DATERANGE_URL = "/weight-service/weight/daterangesnapshot"
+# Weight / body composition. The ``range`` endpoint with ``includeAll=true`` returns
+# every weigh-in per day (under ``dailyWeightSummaries[].allWeightMetrics``), unlike the
+# ``daterangesnapshot`` endpoint which returns only one representative weigh-in per day.
+WEIGHT_RANGE_URL = "/weight-service/weight/range"
 
 # Metrics endpoints.
 TRAINING_READINESS_URL = "/metrics-service/metrics/trainingreadiness"

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1827,6 +1827,11 @@ def test_split_body_composition_by_day_drops_unusable_summaries():
             "not-a-dict-summary",  # Non-dict summary entry.
             None,  # Null summary entry.
             {"summaryDate": "2025-01-09", "allWeightMetrics": [None, "x", 5]},  # Junk.
+            # Dict entries but no numeric timestamp -> all dropped -> summary skipped.
+            {
+                "summaryDate": "2025-01-10",
+                "allWeightMetrics": [{"weight": 5.0}, {"timestampGMT": "nope"}],
+            },
         ]
     }
     result = _split_body_composition_by_day(payload)
@@ -1865,7 +1870,39 @@ def test_split_body_composition_filters_non_dict_weighin_entries():
     assert len(entries) == 2
     assert all(isinstance(e, dict) for e in entries)
     assert [e["weight"] for e in entries] == [75000.0, 75200.0]
-    assert result[date(2025, 1, 5)]["dateWeightList"][0]["weight"] == 75000.0
+
+
+def test_split_body_composition_filters_non_numeric_timestamps():
+    """
+    Weigh-in dicts whose timestamp is missing or non-numeric are filtered out, since the
+    processor divides ``timestampGMT``/``date`` and would crash (and quarantine the
+    whole FileSet) on a non-numeric value.
+
+    Valid entries on the same day are preserved; the ``date`` fallback and a bool (int
+    subclass but never a real timestamp) are exercised.
+    """
+    from datetime import date
+
+    from garmin_health_data.extractor import _split_body_composition_by_day
+
+    payload = {
+        "dailyWeightSummaries": [
+            {
+                "summaryDate": "2025-01-05",
+                "allWeightMetrics": [
+                    {"timestampGMT": "not-a-number", "weight": 1.0},  # Non-numeric.
+                    {"weight": 2.0},  # No timestamp at all.
+                    {"timestampGMT": True, "weight": 3.0},  # bool, not a timestamp.
+                    {"timestampGMT": 1736064000000, "weight": 75000.0},  # Valid.
+                    {"date": 1736107200000, "weight": 75200.0},  # Valid via fallback.
+                ],
+            }
+        ]
+    }
+    result = _split_body_composition_by_day(payload)
+
+    entries = result[date(2025, 1, 5)]["dateWeightList"]
+    assert [e["weight"] for e in entries] == [75000.0, 75200.0]
 
 
 def test_split_activities_list_by_day_groups_by_local_date():

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1800,9 +1800,11 @@ def test_split_body_composition_by_day_empty_input():
 
 def test_split_body_composition_by_day_drops_unusable_summaries():
     """
-    Summaries with no weigh-ins or an unparseable ``summaryDate`` are skipped rather
-    than raising, so one malformed summary can't abort the whole RANGE extraction and
-    lose the well-formed days in the same window.
+    Malformed summaries are skipped rather than raising, so one bad entry can't abort
+    the whole RANGE extraction and lose the well-formed days in the same window.
+
+    Covers empty/missing/non-list ``allWeightMetrics``, unparseable/missing
+    ``summaryDate``, and non-dict summary entries.
     """
     from datetime import date
 
@@ -1820,6 +1822,9 @@ def test_split_body_composition_by_day_drops_unusable_summaries():
             {"summaryDate": "2025-01-07"},  # Missing allWeightMetrics.
             {"summaryDate": "not-a-date", "allWeightMetrics": [{"weight": 1.0}]},
             {"allWeightMetrics": [{"weight": 2.0}]},  # Missing summaryDate.
+            {"summaryDate": "2025-01-08", "allWeightMetrics": {"weight": 3.0}},  # Dict.
+            "not-a-dict-summary",  # Non-dict summary entry.
+            None,  # Null summary entry.
         ]
     }
     result = _split_body_composition_by_day(payload)

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1365,17 +1365,37 @@ def test_extract_range_splits_body_composition_into_per_day_files(tmp_path):
     )
     extractor.user_id = "test-user"
 
-    # Three weigh-ins on two distinct UTC dates.
+    # Three weigh-ins across two local days (two on 2025-01-05, one on 2025-01-20),
+    # in the range endpoint's ``dailyWeightSummaries[].allWeightMetrics`` shape.
     def _ms(dt: datetime) -> int:
         return int(dt.replace(tzinfo=timezone.utc).timestamp() * 1000)
 
     body_comp = GARMIN_DATA_REGISTRY.get_by_name("BODY_COMPOSITION")
     mock_api = MagicMock(
         return_value={
-            "dateWeightList": [
-                {"timestampGMT": _ms(datetime(2025, 1, 5, 8, 0)), "weight": 75000.0},
-                {"timestampGMT": _ms(datetime(2025, 1, 5, 20, 0)), "weight": 74800.0},
-                {"timestampGMT": _ms(datetime(2025, 1, 20, 9, 0)), "weight": 74500.0},
+            "dailyWeightSummaries": [
+                {
+                    "summaryDate": "2025-01-05",
+                    "allWeightMetrics": [
+                        {
+                            "timestampGMT": _ms(datetime(2025, 1, 5, 8, 0)),
+                            "weight": 75000.0,
+                        },
+                        {
+                            "timestampGMT": _ms(datetime(2025, 1, 5, 20, 0)),
+                            "weight": 74800.0,
+                        },
+                    ],
+                },
+                {
+                    "summaryDate": "2025-01-20",
+                    "allWeightMetrics": [
+                        {
+                            "timestampGMT": _ms(datetime(2025, 1, 20, 9, 0)),
+                            "weight": 74500.0,
+                        },
+                    ],
+                },
             ]
         }
     )
@@ -1671,12 +1691,17 @@ def test_garmin_client_exposes_a_delegator_for_every_registered_api_method():
 # ---------------------------------------------------------------------------
 
 
-def test_split_body_composition_by_day_groups_by_utc_date():
+def test_split_body_composition_keeps_multiple_same_day_weighins():
     """
-    Body composition entries with timestampGMT spanning multiple UTC dates must be
-    grouped by date in the splitter's output, with each per-day payload preserving the
-    ``dateWeightList`` wrapper key so the processor parses it identically to the legacy
-    per-day API responses.
+    Regression for #69: a local day with more than one weigh-in must keep every weigh-
+    in.
+
+    The range endpoint groups all of a local day's weigh-ins under one
+    ``dailyWeightSummaries`` entry (keyed by ``summaryDate``) in ``allWeightMetrics``.
+    Two weigh-ins logged on the same local day must land together in that day's file
+    even when their UTC ``timestampGMT`` values straddle midnight (morning local vs.
+    late-evening local), so grouping is by the local ``summaryDate`` rather than the UTC
+    timestamp.
     """
     from datetime import date, datetime, timezone
 
@@ -1686,15 +1711,70 @@ def test_split_body_composition_by_day_groups_by_utc_date():
         return int(dt.replace(tzinfo=timezone.utc).timestamp() * 1000)
 
     payload = {
-        "dateWeightList": [
-            {"timestampGMT": _ms(datetime(2025, 1, 5, 8, 0)), "weight": 75000.0},
-            {"timestampGMT": _ms(datetime(2025, 1, 5, 20, 0)), "weight": 74800.0},
-            {"timestampGMT": _ms(datetime(2025, 1, 7, 7, 0)), "weight": 74500.0},
-            {"timestampGMT": None, "weight": 1.0},  # Skipped: no timestamp.
+        "dailyWeightSummaries": [
+            {
+                "summaryDate": "2026-06-06",
+                "numOfWeightEntries": 2,
+                "allWeightMetrics": [
+                    # Morning weigh-in: 2026-06-06 in UTC.
+                    {
+                        "timestampGMT": _ms(datetime(2026, 6, 6, 23, 0)),
+                        "weight": 75000.0,
+                        "sourceType": "MANUAL",
+                    },
+                    # Evening weigh-in: rolls to 2026-06-07 in UTC, but same local day.
+                    {
+                        "timestampGMT": _ms(datetime(2026, 6, 7, 1, 0)),
+                        "weight": 74800.0,
+                        "sourceType": "MANUAL",
+                    },
+                ],
+            }
         ],
-        # Irrelevant range-wide fields the processor never reads.
-        "startDate": "2025-01-01",
+        "totalAverage": {"weight": 74900.0},
+    }
+    result = _split_body_composition_by_day(payload)
+
+    # Both weigh-ins survive, in a single file for the local day (not split across
+    # 06-06 / 06-07 by UTC, and not collapsed to a single representative weigh-in).
+    assert list(result) == [date(2026, 6, 6)]
+    assert len(result[date(2026, 6, 6)]["dateWeightList"]) == 2
+    weights = {e["weight"] for e in result[date(2026, 6, 6)]["dateWeightList"]}
+    assert weights == {75000.0, 74800.0}
+
+
+def test_split_body_composition_by_day_groups_by_summary_date():
+    """
+    Each ``dailyWeightSummaries`` entry becomes one per-day file keyed by its
+    ``summaryDate`` (the user-facing local day), with the day's ``allWeightMetrics`` re-
+    wrapped under the ``dateWeightList`` key so the processor parses it identically to
+    the legacy per-day API responses.
+
+    Range-level wrapper fields are dropped.
+    """
+    from datetime import date
+
+    from garmin_health_data.extractor import _split_body_composition_by_day
+
+    payload = {
+        "dailyWeightSummaries": [
+            {
+                "summaryDate": "2025-01-05",
+                "allWeightMetrics": [
+                    {"timestampGMT": 1736064000000, "weight": 75000.0},
+                    {"timestampGMT": 1736107200000, "weight": 74800.0},
+                ],
+            },
+            {
+                "summaryDate": "2025-01-07",
+                "allWeightMetrics": [
+                    {"timestampGMT": 1736233200000, "weight": 74500.0},
+                ],
+            },
+        ],
+        # Range-wide wrapper fields the processor never reads.
         "totalAverage": {"weight": 74766.0},
+        "previousDateWeight": {"weight": None},
     }
     result = _split_body_composition_by_day(payload)
 
@@ -1702,50 +1782,49 @@ def test_split_body_composition_by_day_groups_by_utc_date():
     assert len(result[date(2025, 1, 5)]["dateWeightList"]) == 2
     assert result[date(2025, 1, 7)]["dateWeightList"][0]["weight"] == 74500.0
     # Wrapper fields not in the processor's contract are intentionally dropped.
-    assert "startDate" not in result[date(2025, 1, 5)]
     assert "totalAverage" not in result[date(2025, 1, 5)]
+    assert "previousDateWeight" not in result[date(2025, 1, 5)]
 
 
 def test_split_body_composition_by_day_empty_input():
     """
-    Empty / missing ``dateWeightList`` yields an empty mapping; ``_extract_range`` uses
-    that to write zero files (no-op for days the user did not weigh in).
+    Empty / missing ``dailyWeightSummaries`` yields an empty mapping; ``_extract_range``
+    uses that to write zero files (no-op for ranges the user did not weigh in).
     """
     from garmin_health_data.extractor import _split_body_composition_by_day
 
     assert _split_body_composition_by_day({}) == {}
-    assert _split_body_composition_by_day({"dateWeightList": []}) == {}
-    assert _split_body_composition_by_day({"dateWeightList": None}) == {}
+    assert _split_body_composition_by_day({"dailyWeightSummaries": []}) == {}
+    assert _split_body_composition_by_day({"dailyWeightSummaries": None}) == {}
 
 
-def test_split_body_composition_by_day_drops_malformed_timestamps():
+def test_split_body_composition_by_day_drops_unusable_summaries():
     """
-    Non-numeric, out-of-range, or otherwise unconvertible ``timestampGMT`` values are
-    silently dropped rather than raising.
-
-    The Garmin API has always returned a numeric millisecond timestamp, so this is
-    purely defensive: a future API shape change (e.g. ISO-string timestamps) shouldn't
-    abort the whole RANGE extraction for that data type and lose every weigh-in in the
-    window.
+    Summaries with no weigh-ins or an unparseable ``summaryDate`` are skipped rather
+    than raising, so one malformed summary can't abort the whole RANGE extraction and
+    lose the well-formed days in the same window.
     """
-    from datetime import date, datetime, timezone
+    from datetime import date
 
     from garmin_health_data.extractor import _split_body_composition_by_day
 
-    valid_ts = int(datetime(2025, 1, 5, 8, 0, tzinfo=timezone.utc).timestamp() * 1000)
     payload = {
-        "dateWeightList": [
-            {"timestampGMT": valid_ts, "weight": 75000.0},
-            {"timestampGMT": "not-a-number", "weight": 1.0},  # ValueError on int().
-            {"timestampGMT": 10**18, "weight": 2.0},  # Overflow / OSError.
-            {"timestampGMT": [123], "weight": 4.0},  # TypeError on int().
-            {"timestampGMT": "2025-01-05T08:00:00Z", "weight": 3.0},  # ValueError.
+        "dailyWeightSummaries": [
+            {
+                "summaryDate": "2025-01-05",
+                "allWeightMetrics": [
+                    {"timestampGMT": 1736064000000, "weight": 75000.0}
+                ],
+            },
+            {"summaryDate": "2025-01-06", "allWeightMetrics": []},  # No weigh-ins.
+            {"summaryDate": "2025-01-07"},  # Missing allWeightMetrics.
+            {"summaryDate": "not-a-date", "allWeightMetrics": [{"weight": 1.0}]},
+            {"allWeightMetrics": [{"weight": 2.0}]},  # Missing summaryDate.
         ]
     }
     result = _split_body_composition_by_day(payload)
 
-    # Only the valid entry survives; the malformed ones are silently dropped
-    # rather than crashing the splitter.
+    # Only the one well-formed summary survives; the rest are silently dropped.
     assert list(result.keys()) == [date(2025, 1, 5)]
     assert len(result[date(2025, 1, 5)]["dateWeightList"]) == 1
     assert result[date(2025, 1, 5)]["dateWeightList"][0]["weight"] == 75000.0

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1804,7 +1804,8 @@ def test_split_body_composition_by_day_drops_unusable_summaries():
     the whole RANGE extraction and lose the well-formed days in the same window.
 
     Covers empty/missing/non-list ``allWeightMetrics``, unparseable/missing
-    ``summaryDate``, and non-dict summary entries.
+    ``summaryDate``, non-dict summary entries, and summaries whose weigh-in entries are
+    all non-dict.
     """
     from datetime import date
 
@@ -1825,6 +1826,7 @@ def test_split_body_composition_by_day_drops_unusable_summaries():
             {"summaryDate": "2025-01-08", "allWeightMetrics": {"weight": 3.0}},  # Dict.
             "not-a-dict-summary",  # Non-dict summary entry.
             None,  # Null summary entry.
+            {"summaryDate": "2025-01-09", "allWeightMetrics": [None, "x", 5]},  # Junk.
         ]
     }
     result = _split_body_composition_by_day(payload)
@@ -1832,6 +1834,37 @@ def test_split_body_composition_by_day_drops_unusable_summaries():
     # Only the one well-formed summary survives; the rest are silently dropped.
     assert list(result.keys()) == [date(2025, 1, 5)]
     assert len(result[date(2025, 1, 5)]["dateWeightList"]) == 1
+
+
+def test_split_body_composition_filters_non_dict_weighin_entries():
+    """
+    Within an otherwise valid summary, non-dict weigh-in entries are filtered out so the
+    processor never receives a non-dict it would crash on, while the valid dict entries
+    on that day are preserved.
+    """
+    from datetime import date
+
+    from garmin_health_data.extractor import _split_body_composition_by_day
+
+    payload = {
+        "dailyWeightSummaries": [
+            {
+                "summaryDate": "2025-01-05",
+                "allWeightMetrics": [
+                    None,
+                    "not-a-dict",
+                    {"timestampGMT": 1736064000000, "weight": 75000.0},
+                    {"timestampGMT": 1736107200000, "weight": 75200.0},
+                ],
+            }
+        ]
+    }
+    result = _split_body_composition_by_day(payload)
+
+    entries = result[date(2025, 1, 5)]["dateWeightList"]
+    assert len(entries) == 2
+    assert all(isinstance(e, dict) for e in entries)
+    assert [e["weight"] for e in entries] == [75000.0, 75200.0]
     assert result[date(2025, 1, 5)]["dateWeightList"][0]["weight"] == 75000.0
 
 

--- a/tests/test_garmin_client_api.py
+++ b/tests/test_garmin_client_api.py
@@ -12,29 +12,39 @@ from garmin_health_data.garmin_client import api
 
 class TestGetBodyComposition:
     """
-    Tests for :func:`api.get_body_composition` empty-response normalization.
+    Tests for :func:`api.get_body_composition` endpoint and empty-response
+    normalization.
 
-    The Garmin weight endpoint returns a populated wrapper dict on no-data days
-    (``{startDate, endDate, dateWeightList: [], totalAverage: {...nulls...}}``). Without
-    normalization the extractor would write one useless JSON file per day for users
-    without scale data, since a non-empty dict is truthy. ``get_body_composition`` must
-    collapse that shape to ``None`` so the extractor short-circuits.
+    Body composition is fetched from the ``/weight-service/weight/range/{start}/{end}``
+    endpoint with ``includeAll=true``, which returns *every* weigh-in per day under
+    ``dailyWeightSummaries[].allWeightMetrics``. (The previous ``daterangesnapshot``
+    endpoint returned only one representative weigh-in per day, dropping morning/evening
+    weigh-ins; see #69.) On no-data ranges the endpoint returns a populated wrapper dict
+    with an empty ``dailyWeightSummaries`` and a ``totalAverage`` of nulls; without
+    normalization the extractor would write a useless JSON file for users without scale
+    data, since a non-empty dict is truthy. ``get_body_composition`` collapses that
+    shape to ``None`` so the extractor short-circuits.
     """
 
-    def test_returns_payload_when_weighins_present(self) -> None:
+    def test_calls_range_includeall_endpoint(self) -> None:
         """
-        A populated ``dateWeightList`` must be returned verbatim so the extractor saves
-        the file and the processor can map fields downstream.
+        The wrapper must hit ``/weight-service/weight/range/{start}/{end}`` with
+        ``includeAll=true`` so the API returns all weigh-ins per day, not the one-per-
+        day snapshot.
         """
         payload = {
-            "startDate": "2026-04-15",
-            "endDate": "2026-04-15",
-            "dateWeightList": [
+            "dailyWeightSummaries": [
                 {
-                    "timestampGMT": 1713182400000,
-                    "weight": 75300.0,
-                    "bmi": 24.5,
-                    "sourceType": "INDEX_SCALE",
+                    "summaryDate": "2026-04-15",
+                    "numOfWeightEntries": 1,
+                    "allWeightMetrics": [
+                        {
+                            "timestampGMT": 1713182400000,
+                            "weight": 75300.0,
+                            "bmi": 24.5,
+                            "sourceType": "INDEX_SCALE",
+                        }
+                    ],
                 }
             ],
             "totalAverage": {"weight": 75300.0},
@@ -46,40 +56,37 @@ class TestGetBodyComposition:
 
         assert result is payload
         client._connectapi.assert_called_once_with(
-            api.WEIGHT_DATERANGE_URL,
-            params={"startDate": "2026-04-15", "endDate": "2026-04-15"},
+            f"{api.WEIGHT_RANGE_URL}/2026-04-15/2026-04-15",
+            params={"includeAll": True},
         )
 
-    def test_returns_none_when_date_weight_list_empty(self) -> None:
+    def test_returns_none_when_summaries_empty(self) -> None:
         """
-        On no-data days the API returns the wrapper dict with an empty
-        ``dateWeightList``.
+        On no-data ranges the API returns the wrapper dict with an empty
+        ``dailyWeightSummaries``.
 
         ``get_body_composition`` must collapse that to ``None`` so the extractor's
         truthiness check skips the file write.
         """
         client = MagicMock()
         client._connectapi.return_value = {
-            "startDate": "2026-04-15",
-            "endDate": "2026-04-15",
-            "dateWeightList": [],
+            "dailyWeightSummaries": [],
             "totalAverage": {"weight": None, "bmi": None},
+            "previousDateWeight": {"weight": None},
+            "nextDateWeight": {"weight": None},
         }
 
         result = api.get_body_composition(client, "2026-04-15")
 
         assert result is None
 
-    def test_returns_none_when_date_weight_list_missing(self) -> None:
+    def test_returns_none_when_summaries_missing(self) -> None:
         """
-        Defensive: if the endpoint ever omits ``dateWeightList`` entirely, treat that as
-        no data rather than letting a wrapper-only dict through.
+        Defensive: if the endpoint ever omits ``dailyWeightSummaries`` entirely, treat
+        that as no data rather than letting a wrapper-only dict through.
         """
         client = MagicMock()
-        client._connectapi.return_value = {
-            "startDate": "2026-04-15",
-            "endDate": "2026-04-15",
-        }
+        client._connectapi.return_value = {"totalAverage": {"weight": None}}
 
         result = api.get_body_composition(client, "2026-04-15")
 
@@ -99,21 +106,21 @@ class TestGetBodyComposition:
 
     def test_default_enddate_matches_startdate(self) -> None:
         """
-        When ``enddate`` is omitted, ``startdate`` is used for both bounds (single-day
-        query).
+        When ``enddate`` is omitted, ``startdate`` is used for both path bounds (single-
+        day query).
 
         The extractor itself calls this wrapper with the full requested window via
         ``_extract_range``; the default-enddate behavior is for direct callers
         (ad-hoc scripts, the activities downloader's per-day fallback).
         """
         client = MagicMock()
-        client._connectapi.return_value = {"dateWeightList": []}
+        client._connectapi.return_value = {"dailyWeightSummaries": []}
 
         api.get_body_composition(client, "2026-04-15")
 
         client._connectapi.assert_called_once_with(
-            api.WEIGHT_DATERANGE_URL,
-            params={"startDate": "2026-04-15", "endDate": "2026-04-15"},
+            f"{api.WEIGHT_RANGE_URL}/2026-04-15/2026-04-15",
+            params={"includeAll": True},
         )
 
 

--- a/tests/test_garmin_client_api.py
+++ b/tests/test_garmin_client_api.py
@@ -57,7 +57,7 @@ class TestGetBodyComposition:
         assert result is payload
         client._connectapi.assert_called_once_with(
             f"{api.WEIGHT_RANGE_URL}/2026-04-15/2026-04-15",
-            params={"includeAll": True},
+            params={"includeAll": "true"},
         )
 
     def test_returns_none_when_summaries_empty(self) -> None:
@@ -120,7 +120,7 @@ class TestGetBodyComposition:
 
         client._connectapi.assert_called_once_with(
             f"{api.WEIGHT_RANGE_URL}/2026-04-15/2026-04-15",
-            params={"includeAll": True},
+            params={"includeAll": "true"},
         )
 
 


### PR DESCRIPTION
## Summary

Fixes #69. Multiple weigh-ins on the same day were silently collapsed to one.

**Root cause:** extraction called `/weight-service/weight/daterangesnapshot` (the endpoint behind Garmin Connect's weight *trend chart*), which returns only **one representative weigh-in per calendar day**. Users who weigh more than once a day lost all but one at the API boundary — regardless of the `(user_id, timestamp)` primary key on `body_composition` meant to hold multiple. This predates #65: the endpoint was `daterangesnapshot` since the feature's introduction in #49, and #65 only changed the call cadence, not the endpoint, so "multiple weigh-ins per day are preserved" was never actually true end-to-end.

**Fix:** switch to `/weight-service/weight/range/{start}/{end}?includeAll=true`, which returns every weigh-in grouped under `dailyWeightSummaries[].allWeightMetrics`. The per-day splitter reads that shape and groups by Garmin's local `summaryDate` (not each weigh-in's UTC `timestampGMT`), so two weigh-ins on the same local day land in one per-day file even when their UTC timestamps straddle midnight (mirrors the `ACTIVITIES_LIST` splitter). Still one API call per window (the #65 optimization is preserved), and the per-day file shape at the processor boundary (`dateWeightList`) is unchanged, so `_process_body_composition` is untouched.

## Verification (live API, real account)

| Endpoint | Weigh-ins returned for a real multi-weigh-in day |
|---|---|
| OLD `daterangesnapshot` | **1** |
| NEW `range?includeAll=true` | **2** |

Extracted → processed → **2 distinct `body_composition` rows** written. The test day happened to be the midnight-straddle case (17:04 UTC + 05:03 UTC next day, both local same day) and the splitter grouped both correctly. Confirmed `allWeightMetrics` carries the same field names the processor already reads.

## Tests / gates

- 393 passed, 1 skipped.
- `make check-format` clean.
- New coverage: multi-same-day-weighin splitting, midnight-straddle grouping, empty/unusable-summary skipping, and API-layer assertions on the new URL + `includeAll=true` + empty→`None` normalization.

Not a release — version stays 2.11.2, changelog entry under `[Unreleased]`.