### PR TITLE
feat: add --exclude-data-types flag to extract (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-08-07
+
+### Added
+
+- **`--exclude-data-types` flag for `garmin extract`** ([#79](https://github.com/diegoscarabelli/garmin-health-data/issues/79)). Extracts every registered data type *except* the named ones, so a caller can skip a type (e.g. `MENSTRUAL_CYCLE_DAY` and its ~90-day retroactive re-fetch) without enumerating the ~20 types they do want. Unlike a hardcoded `--data-types` allowlist, exclusion is forward-compatible: data types added to the tool later are still extracted by default. Mutually exclusive with `--data-types`; an unknown excluded name or excluding every type aborts with a clear error before any work.
+
 ### Fixed
 
 - **`extract` no longer calls the API when the database is already up to date** ([#77](https://github.com/diegoscarabelli/garmin-health-data/issues/77)). The auto-detected start is `get_latest_date() + 1 day`, which on a current database lands on tomorrow while the end defaults to today. Only `DAILY` types treated that inverted window as empty: `RANGE` types still fired with a backwards range (two returning HTTP 400 through the full retry ladder), `NO_DATE` types re-downloaded regardless, and `_retroactive_lookback_start` revived the window into ~90 days of `MENSTRUAL_CYCLE_DAY` calls — ~98 API calls for a no-op run. `extract()` now returns early once the resolved start is after the resolved end. Same-day windows stay inclusive and still dispatch. The CLI also tidies its `Date range` line: it is suppressed for this no-op case (previously a confusing backwards range), and a same-day window is labeled `single day, inclusive` rather than the misleading `(exclusive)`.
@@ -434,7 +440,8 @@ All data can be re-downloaded from Garmin Connect. This is the cleanest upgrade 
 - Flexible authentication with OAuth tokens.
 - Comprehensive documentation and examples.
 
-[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.12.0...HEAD
+[Unreleased]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.13.0...HEAD
+[2.13.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.12.0...v2.13.0
 [2.12.0]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.11.2...v2.12.0
 [2.11.2]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.11.1...v2.11.2
 [2.11.1]: https://github.com/diegoscarabelli/garmin-health-data/compare/v2.11.0...v2.11.1

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ garmin extract --start-date 2024-01-01 --end-date 2024-12-31
 # Specific data types
 garmin extract --data-types SLEEP --data-types HEART_RATE --data-types ACTIVITY
 
+# All types except some (forward-compatible; mutually exclusive with --data-types)
+garmin extract --exclude-data-types MENSTRUAL_CYCLE_DAY
+
 # Specific accounts (comma- or repeat-style)
 garmin extract --accounts 12345678,87654321
 
@@ -289,7 +292,8 @@ Performs a fresh interactive login and stores OAuth tokens in `~/.garminconnect/
 | --- | --- | --- |
 | `--start-date YYYY-MM-DD` | Inclusive | Auto-detected from the database if omitted (day after the latest stored data, or 30 days ago for an empty DB). |
 | `--end-date YYYY-MM-DD` | Exclusive (except same-day = inclusive) | Defaults to today. |
-| `--data-types NAME` | Repeatable, e.g. `--data-types SLEEP --data-types HEART_RATE` | Filter to specific [data types](#data-types). All types extracted if omitted. |
+| `--data-types NAME` | Repeatable, e.g. `--data-types SLEEP --data-types HEART_RATE` | Filter to specific [data types](#data-types). All types extracted if omitted. Mutually exclusive with `--exclude-data-types`. |
+| `--exclude-data-types NAME` | Repeatable, e.g. `--exclude-data-types MENSTRUAL_CYCLE_DAY` | Extract every [data type](#data-types) *except* these (forward-compatible: types added to the tool later are still extracted). Mutually exclusive with `--data-types`. |
 | `--accounts ID` | Repeatable or comma-separated | Filter to specific Garmin user IDs (`--accounts 12345 --accounts 67890` or `--accounts 12345,67890`). All discovered accounts extracted if omitted. |
 | `--db-path PATH` | File path | SQLite database file. Defaults to `./garmin_data.db`. |
 | `--extract-only` | Flag | Download to `garmin_files/ingest/` and stop; do not load into the DB. |

--- a/garmin_health_data/cli.py
+++ b/garmin_health_data/cli.py
@@ -249,6 +249,40 @@ def extract(
         )
         raise click.Abort()
 
+    # Resolve the effective data-type allowlist before any auth or DB work, so a
+    # bad flag combination aborts immediately. --data-types and
+    # --exclude-data-types are mutually exclusive: --data-types is an explicit
+    # allowlist; --exclude-data-types extracts every registry type except the
+    # named ones (forward-compatible, so types added later are still included).
+    if data_types and exclude_data_types:
+        click.secho(
+            "❌ --data-types and --exclude-data-types are mutually exclusive.",
+            fg="red",
+        )
+        raise click.Abort()
+
+    if exclude_data_types:
+        all_names = [dt.name for dt in GARMIN_DATA_REGISTRY.all_data_types]
+        invalid = sorted(name for name in exclude_data_types if name not in all_names)
+        if invalid:
+            click.secho(
+                f"❌ Invalid --exclude-data-types name(s): {', '.join(invalid)}. "
+                f"Valid types: {', '.join(all_names)}.",
+                fg="red",
+            )
+            raise click.Abort()
+        excluded = set(exclude_data_types)
+        data_types_list = [name for name in all_names if name not in excluded]
+        if not data_types_list:
+            click.secho(
+                "❌ --exclude-data-types excludes every data type; "
+                "nothing left to extract.",
+                fg="red",
+            )
+            raise click.Abort()
+    else:
+        data_types_list = list(data_types) if data_types else None
+
     # Authentication is only required when we will hit the Garmin API.
     if not process_only:
         ensure_authenticated()
@@ -291,40 +325,6 @@ def extract(
         click.secho(f"❌ {e}", fg="red")
         raise click.Abort() from e
 
-    # Date auto-detection and extract-only logging are skipped when running
-    # in --process-only mode (no API calls, dates would be unused).
-    # Resolve the effective data-type allowlist. --data-types and
-    # --exclude-data-types are mutually exclusive: --data-types is an explicit
-    # allowlist; --exclude-data-types extracts every registry type except the
-    # named ones (forward-compatible, so types added later are still included).
-    if data_types and exclude_data_types:
-        click.secho(
-            "❌ --data-types and --exclude-data-types are mutually exclusive.",
-            fg="red",
-        )
-        raise click.Abort()
-
-    if exclude_data_types:
-        all_names = [dt.name for dt in GARMIN_DATA_REGISTRY.all_data_types]
-        invalid = [name for name in exclude_data_types if name not in all_names]
-        if invalid:
-            click.secho(
-                f"❌ Invalid --exclude-data-types name(s): {invalid}. "
-                f"Valid types: {', '.join(all_names)}.",
-                fg="red",
-            )
-            raise click.Abort()
-        excluded = set(exclude_data_types)
-        data_types_list = [name for name in all_names if name not in excluded]
-        if not data_types_list:
-            click.secho(
-                "❌ --exclude-data-types excludes every data type; "
-                "nothing left to extract.",
-                fg="red",
-            )
-            raise click.Abort()
-    else:
-        data_types_list = list(data_types) if data_types else None
     accounts_list = (
         [a.strip() for raw in accounts for a in raw.split(",") if a.strip()]
         if accounts
@@ -343,6 +343,8 @@ def extract(
                 f"--accounts contains a non-integer user_id: {exc}"
             ) from exc
 
+    # Date auto-detection and extract-only logging are skipped when running
+    # in --process-only mode (no API calls, dates would be unused).
     if not process_only:
         # Auto-detect start date if not provided.
         if start_date is None:

--- a/garmin_health_data/cli.py
+++ b/garmin_health_data/cli.py
@@ -18,7 +18,7 @@ from garmin_health_data.auth import (
     get_credentials,
     refresh_tokens,
 )
-from garmin_health_data.constants import GARMIN_FILE_TYPES
+from garmin_health_data.constants import GARMIN_DATA_REGISTRY, GARMIN_FILE_TYPES
 from garmin_health_data.db import (
     create_tables,
     database_exists,
@@ -137,7 +137,14 @@ def auth(email: Optional[str], password: Optional[str]):
     "--data-types",
     multiple=True,
     help="Specific data types to extract (can specify multiple times). "
-    "Extracts all if not specified.",
+    "Extracts all if not specified. Mutually exclusive with "
+    "--exclude-data-types.",
+)
+@click.option(
+    "--exclude-data-types",
+    multiple=True,
+    help="Data types to exclude; extracts every type except these (can specify "
+    "multiple times). Mutually exclusive with --data-types.",
 )
 @click.option(
     "--db-path",
@@ -193,6 +200,7 @@ def extract(
     start_date: Optional[datetime],
     end_date: Optional[datetime],
     data_types: tuple,
+    exclude_data_types: tuple,
     db_path: str,
     accounts: tuple,
     extract_only: bool,
@@ -285,7 +293,38 @@ def extract(
 
     # Date auto-detection and extract-only logging are skipped when running
     # in --process-only mode (no API calls, dates would be unused).
-    data_types_list = list(data_types) if data_types else None
+    # Resolve the effective data-type allowlist. --data-types and
+    # --exclude-data-types are mutually exclusive: --data-types is an explicit
+    # allowlist; --exclude-data-types extracts every registry type except the
+    # named ones (forward-compatible, so types added later are still included).
+    if data_types and exclude_data_types:
+        click.secho(
+            "❌ --data-types and --exclude-data-types are mutually exclusive.",
+            fg="red",
+        )
+        raise click.Abort()
+
+    if exclude_data_types:
+        all_names = [dt.name for dt in GARMIN_DATA_REGISTRY.all_data_types]
+        invalid = [name for name in exclude_data_types if name not in all_names]
+        if invalid:
+            click.secho(
+                f"❌ Invalid --exclude-data-types name(s): {invalid}. "
+                f"Valid types: {', '.join(all_names)}.",
+                fg="red",
+            )
+            raise click.Abort()
+        excluded = set(exclude_data_types)
+        data_types_list = [name for name in all_names if name not in excluded]
+        if not data_types_list:
+            click.secho(
+                "❌ --exclude-data-types excludes every data type; "
+                "nothing left to extract.",
+                fg="red",
+            )
+            raise click.Abort()
+    else:
+        data_types_list = list(data_types) if data_types else None
     accounts_list = (
         [a.strip() for raw in accounts for a in raw.split(",") if a.strip()]
         if accounts
@@ -336,7 +375,12 @@ def extract(
         if end_date is None:
             end_date = datetime.now()
 
-        if data_types_list:
+        if exclude_data_types:
+            click.echo(
+                "📊 Extracting all data types except: "
+                f"{', '.join(exclude_data_types)}"
+            )
+        elif data_types_list:
             click.echo(f"📊 Extracting data types: {', '.join(data_types_list)}")
         else:
             click.echo("📊 Extracting all available data types")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garmin-health-data"
-version = "2.12.0"
+version = "2.13.0"
 description = "Download Garmin Connect health data as local files and load it into a SQLite database for analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -555,3 +555,150 @@ def test_extract_labels_same_day_window_inclusive(tmp_path):
     assert result.exit_code == 0, result.output
     assert "single day, inclusive" in result.output
     assert "(exclusive)" not in result.output
+
+
+def test_extract_exclude_data_types_extracts_all_but_excluded(tmp_path):
+    """
+    --exclude-data-types resolves to every registry type except the excluded one(s),
+    handed to extract_data as an explicit list (forward-compatible: types added later
+    are still included).
+    """
+    from garmin_health_data.constants import GARMIN_DATA_REGISTRY
+
+    db_path = tmp_path / "test.db"
+    create_tables(str(db_path))
+
+    captured = {}
+
+    def capture(*args, **kwargs):
+        captured["data_types"] = kwargs.get("data_types")
+        return _stub_extract_no_files()
+
+    runner = CliRunner()
+    with (
+        patch("garmin_health_data.cli.ensure_authenticated"),
+        patch("garmin_health_data.cli.extract_data", side_effect=capture),
+    ):
+        result = runner.invoke(
+            extract,
+            ["--db-path", str(db_path), "--exclude-data-types", "MENSTRUAL_CYCLE_DAY"],
+        )
+
+    assert result.exit_code == 0, result.output
+    expected = [
+        d.name
+        for d in GARMIN_DATA_REGISTRY.all_data_types
+        if d.name != "MENSTRUAL_CYCLE_DAY"
+    ]
+    assert captured["data_types"] == expected
+
+
+def test_extract_rejects_data_types_with_exclude_data_types(tmp_path):
+    """
+    --data-types and --exclude-data-types are mutually exclusive; supplying both aborts
+    before any extraction.
+    """
+    db_path = tmp_path / "test.db"
+    create_tables(str(db_path))
+
+    runner = CliRunner()
+    with (
+        patch("garmin_health_data.cli.ensure_authenticated"),
+        patch(
+            "garmin_health_data.cli.extract_data",
+            side_effect=_stub_extract_no_files,
+        ) as mock_extract,
+    ):
+        result = runner.invoke(
+            extract,
+            [
+                "--db-path",
+                str(db_path),
+                "--data-types",
+                "SLEEP",
+                "--exclude-data-types",
+                "STRESS",
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+    mock_extract.assert_not_called()
+
+
+def test_extract_rejects_unknown_exclude_data_type(tmp_path):
+    """
+    An unknown --exclude-data-types name aborts with an error naming the offender.
+    """
+    db_path = tmp_path / "test.db"
+    create_tables(str(db_path))
+
+    runner = CliRunner()
+    with (
+        patch("garmin_health_data.cli.ensure_authenticated"),
+        patch(
+            "garmin_health_data.cli.extract_data",
+            side_effect=_stub_extract_no_files,
+        ) as mock_extract,
+    ):
+        result = runner.invoke(
+            extract,
+            ["--db-path", str(db_path), "--exclude-data-types", "NOTAREALTYPE"],
+        )
+
+    assert result.exit_code != 0
+    assert "NOTAREALTYPE" in result.output
+    mock_extract.assert_not_called()
+
+
+def test_extract_rejects_excluding_all_data_types(tmp_path):
+    """
+    Excluding every registry type leaves nothing to extract, which aborts.
+    """
+    from garmin_health_data.constants import GARMIN_DATA_REGISTRY
+
+    db_path = tmp_path / "test.db"
+    create_tables(str(db_path))
+
+    exclude_args = []
+    for data_type in GARMIN_DATA_REGISTRY.all_data_types:
+        exclude_args += ["--exclude-data-types", data_type.name]
+
+    runner = CliRunner()
+    with (
+        patch("garmin_health_data.cli.ensure_authenticated"),
+        patch(
+            "garmin_health_data.cli.extract_data",
+            side_effect=_stub_extract_no_files,
+        ) as mock_extract,
+    ):
+        result = runner.invoke(extract, ["--db-path", str(db_path), *exclude_args])
+
+    assert result.exit_code != 0
+    assert "nothing left to extract" in result.output
+    mock_extract.assert_not_called()
+
+
+def test_extract_exclude_data_types_prints_exclusion_summary(tmp_path):
+    """
+    In exclude mode the CLI names the excluded types rather than dumping the full
+    resolved allowlist of every other type.
+    """
+    db_path = tmp_path / "test.db"
+    create_tables(str(db_path))
+
+    runner = CliRunner()
+    with (
+        patch("garmin_health_data.cli.ensure_authenticated"),
+        patch(
+            "garmin_health_data.cli.extract_data",
+            side_effect=_stub_extract_no_files,
+        ),
+    ):
+        result = runner.invoke(
+            extract,
+            ["--db-path", str(db_path), "--exclude-data-types", "MENSTRUAL_CYCLE_DAY"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Extracting all data types except: MENSTRUAL_CYCLE_DAY" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -702,3 +702,28 @@ def test_extract_exclude_data_types_prints_exclusion_summary(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert "Extracting all data types except: MENSTRUAL_CYCLE_DAY" in result.output
+
+
+def test_extract_validates_exclude_options_before_auth(tmp_path):
+    """
+    Invalid exclude options abort before ensure_authenticated() (and before any DB or
+    lock work), so a typo never triggers an auth prompt or database mutation.
+    """
+    db_path = tmp_path / "test.db"
+    create_tables(str(db_path))
+
+    runner = CliRunner()
+    with (
+        patch("garmin_health_data.cli.ensure_authenticated") as mock_auth,
+        patch(
+            "garmin_health_data.cli.extract_data",
+            side_effect=_stub_extract_no_files,
+        ),
+    ):
+        result = runner.invoke(
+            extract,
+            ["--db-path", str(db_path), "--exclude-data-types", "NOTAREALTYPE"],
+        )
+
+    assert result.exit_code != 0
+    mock_auth.assert_not_called()


### PR DESCRIPTION
## Summary

Adds `--exclude-data-types` to `garmin extract`: extract every registered data type *except* the named ones, so you can skip a type without enumerating the ~20 you want.

Motivating case (#79): skipping `MENSTRUAL_CYCLE_DAY` avoids its ~90-day retroactive re-fetch (~90 API calls/run) for users who don't track it. Unlike a hardcoded `--data-types` allowlist, exclusion is **forward-compatible**: data types added to the tool later are still extracted by default.

## Behavior

- Mutually exclusive with `--data-types` (supplying both aborts with a clear error).
- Unknown excluded name aborts, listing the valid types.
- Excluding every type aborts ("nothing left to extract").
- Prints `Extracting all data types except: <names>` instead of the full resolved allowlist.
- Resolves in the CLI to an explicit all-minus-excluded list, so `extract()`'s signature is unchanged and the openetl/Airflow caller is unaffected.

## Release

Prepared as **2.13.0** (minor, backward-compatible): version bump plus a CHANGELOG section that folds in the already-merged #77 no-op fix. Tagging / the GitHub Release (which triggers the PyPI publish workflow) remains a post-merge step.

## Testing

- 5 new `test_cli.py` tests (resolution, mutual-exclusivity, unknown name, exclude-all, exclusion-summary print), written test-first.
- Full suite: 435 passed, 1 skipped. All `check-format` gates (black, autoflake, docformatter, sqlfluff) pass.

Closes #79.