### PR TITLE
fix: make extraction filenames deterministic across pendulum versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.1] - 2026-08-16
+
+### Fixed
+
+- **Extraction filenames are now deterministic across `pendulum` versions, so valid files are no longer quarantined** ([#83](https://github.com/diegoscarabelli/garmin-health-data/pull/83)). The extractor stamped every filename via `pendulum.instance(midday_dt, tz="UTC").to_iso8601_string()`, whose rendering of a UTC instant changed between `pendulum` major versions: 3.x emits `...T12:00:00Z` (written to disk as `...T12-00-00Z` after the colon-to-hyphen swap), while 2.x emits `...T12:00:00+00:00` (written as `...T12-00-00+00-00`). The processor's three filename patterns accepted `Z` but not `+`, so on any environment that resolved `pendulum` 2.x every extracted JSON/FIT/TCX file failed `_parse_filename` and was routed to quarantine, leaving an empty database. The offset was always UTC (`+00:00`), never a local zone: all three filename paths force `tz="UTC"`. Filenames are now built by a single helper as a fixed, colon-free, `Z`-suffixed `YYYY-MM-DDT12-00-00Z` string that does not depend on the installed `pendulum` version, and the fragile whole-filename `.replace(":", "-")` is gone. So files already quarantined by an affected install can be recovered, the processor's three patterns also still accept the legacy `+00-00` offset form: move those files back into the ingest directory and re-run to load them. Reported by @OleMantei.
+
 ## [2.14.0] - 2026-08-14
 
 ### Changed

--- a/garmin_health_data/extractor.py
+++ b/garmin_health_data/extractor.py
@@ -13,7 +13,7 @@ import zipfile
 import io
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, date
+from datetime import timedelta, date
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -344,6 +344,25 @@ def _detect_format_from_magic(content: bytes) -> Optional[str]:
         return "kml"
 
     return None
+
+
+def _utc_midday_stamp(day: date) -> str:
+    """
+    Build the deterministic filename timestamp shared by a day's extracted files.
+
+    All files extracted for a given calendar day are stamped with one midday-UTC
+    timestamp so the processor can group them into a single ``FileSet``. The stamp is
+    rendered as ``YYYY-MM-DDT12-00-00Z``: colon-free (safe on every filesystem) and
+    always suffixed with ``Z``. Building the string directly, instead of formatting a
+    ``pendulum`` instance, keeps the on-disk name independent of the installed
+    ``pendulum`` version, whose ISO-8601 rendering of a UTC instant differs across major
+    releases (2.x emits ``+00:00``, 3.x emits ``Z``) and previously produced
+    ``+``-bearing names the processor refused to parse.
+
+    :param day: Calendar day the file's data belongs to.
+    :return: Filename timestamp of the form ``YYYY-MM-DDT12-00-00Z``.
+    """
+    return f"{day.isoformat()}T12-00-00Z"
 
 
 class GarminExtractor:
@@ -876,14 +895,11 @@ class GarminExtractor:
         :param file_date: Date for timestamp generation used in filename.
         :return: List of saved file paths.
         """
-        # Create midday timestamp for consistent grouping.
-        midday_dt = datetime.combine(file_date, datetime.min.time()).replace(
-            hour=12, minute=0, second=0
-        )
-        timestamp = pendulum.instance(midday_dt, tz="UTC").to_iso8601_string()
+        # Deterministic midday-UTC timestamp shared by the day's files for grouping.
+        timestamp = _utc_midday_stamp(file_date)
 
         # Generate filename: {user_id}_{DATA_TYPE}_{timestamp}.json.
-        filename = f"{self.user_id}_{data_type.name}_{timestamp}.json".replace(":", "-")
+        filename = f"{self.user_id}_{data_type.name}_{timestamp}.json"
         filepath = self.ingest_dir / filename
 
         # Save data.
@@ -1111,15 +1127,11 @@ class GarminExtractor:
         for activity in activities:
             activity_id = activity["activityId"]
 
-            # Generate timestamp with local timezone date at noon for
-            # consistent batching with ACTIVITIES_LIST file. Uses same
-            # midday timestamp approach as _save_garmin_data().
-            activity_start = pendulum.parse(activity.get("startTimeLocal"))
-            activity_date = activity_start.date()
-            midday_dt = datetime.combine(activity_date, datetime.min.time()).replace(
-                hour=12, minute=0, second=0
-            )
-            timestamp = pendulum.instance(midday_dt, tz="UTC").to_iso8601_string()
+            # Stamp the activity's files with the local start date at midday UTC so
+            # they batch with that day's ACTIVITIES_LIST file, using the same
+            # deterministic midday timestamp as _save_garmin_data().
+            activity_date = pendulum.parse(activity.get("startTimeLocal")).date()
+            timestamp = _utc_midday_stamp(activity_date)
 
             # Download and save the activity file (ORIGINAL = ZIP archive), only when
             # ACTIVITY is requested. A 404 means the activity has no downloadable file
@@ -1163,7 +1175,7 @@ class GarminExtractor:
                     filename = (
                         f"{self.user_id}_ACTIVITY_{activity_id}_"
                         f"{timestamp}.{file_ext}"
-                    ).replace(":", "-")
+                    )
                     filepath = self.ingest_dir / filename
                     with open(filepath, "wb") as f:
                         f.write(file_content)
@@ -1237,9 +1249,7 @@ class GarminExtractor:
             click.echo(f"No exercise sets data for activity {activity_id}.")
             return None
 
-        filename = (
-            f"{self.user_id}_EXERCISE_SETS_{activity_id}_{timestamp}.json"
-        ).replace(":", "-")
+        filename = f"{self.user_id}_EXERCISE_SETS_{activity_id}_{timestamp}.json"
         filepath = self.ingest_dir / filename
 
         with open(filepath, "w", encoding="utf-8") as f:
@@ -1308,7 +1318,7 @@ class GarminExtractor:
         filename = (
             f"{self.user_id}_MULTISPORT_CHILDREN_"
             f"{parent_activity_id}_{timestamp}.json"
-        ).replace(":", "-")
+        )
         filepath = self.ingest_dir / filename
         with open(filepath, "w", encoding="utf-8") as f:
             json.dump(

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -376,7 +376,10 @@ class GarminProcessor(Processor):
         :return: Dictionary with `user_id`, `data_type`, and `timestamp`.
         :raises ValueError: If filename doesn't match expected pattern.
         """
-        pattern = r"^(\d+)_([A-Z_]+)(?:_\d+)?_([0-9T:\-Z\.]+)\.(json|fit|tcx)$"
+        # ``+`` in the timestamp class lets legacy filenames written by a pre-2.14.1
+        # extractor on pendulum 2.x (which stamped a ``+00-00`` UTC offset) still
+        # parse, so files quarantined by an affected install can be recovered.
+        pattern = r"^(\d+)_([A-Z_]+)(?:_\d+)?_([0-9T:+\-Z\.]+)\.(json|fit|tcx)$"
         match = re.match(pattern, filename)
 
         if not match:
@@ -3332,7 +3335,8 @@ class GarminProcessor(Processor):
         # Extract `activity_id` from filename.
         # FIT files have format: {user_id}_ACTIVITY_{activity_id}_{timestamp}.fit
         # Use regex to extract activity_id directly from filename.
-        pattern = r"^(\d+)_ACTIVITY_(\d+)_([0-9T:\-Z\.]+)\.fit$"
+        # ``+`` retained so legacy pre-2.14.1 ``+00-00`` filenames still parse.
+        pattern = r"^(\d+)_ACTIVITY_(\d+)_([0-9T:+\-Z\.]+)\.fit$"
         match = re.match(pattern, file_path.name)
 
         if not match:
@@ -3600,7 +3604,8 @@ class GarminProcessor(Processor):
         :param session: SQLAlchemy Session object.
         """
         # TCX files share the same naming convention as FIT files.
-        pattern = r"^(\d+)_ACTIVITY_(\d+)_([0-9T:\-Z\.]+)\.tcx$"
+        # ``+`` retained so legacy pre-2.14.1 ``+00-00`` filenames still parse.
+        pattern = r"^(\d+)_ACTIVITY_(\d+)_([0-9T:+\-Z\.]+)\.tcx$"
         match = re.match(pattern, file_path.name)
 
         if not match:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garmin-health-data"
-version = "2.14.0"
+version = "2.14.1"
 description = "Download Garmin Connect health data as local files and load it into a SQLite database for analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -16,6 +16,7 @@ from garmin_health_data.constants import GARMIN_DATA_REGISTRY
 from garmin_health_data.extractor import (
     GarminExtractor,
     _detect_format_from_magic,
+    _utc_midday_stamp,
     extract,
 )
 
@@ -2506,3 +2507,49 @@ class TestMenstrualCycleDayGate:
 
         # Assert.
         assert result is True
+
+
+class TestUtcMiddayStamp:
+    """
+    Tests for the deterministic filename timestamp builder.
+    """
+
+    def test_renders_fixed_midday_utc_format(self):
+        """
+        A calendar day renders as a colon-free, ``Z``-suffixed midday-UTC stamp.
+        """
+        assert _utc_midday_stamp(date(2026, 8, 15)) == "2026-08-15T12-00-00Z"
+
+    def test_stamp_is_offset_free_and_filesystem_safe(self):
+        """
+        The stamp never contains a colon or a ``+`` offset, so it is safe on every
+        filesystem and parses regardless of the installed pendulum version.
+        """
+        stamp = _utc_midday_stamp(date(2026, 1, 2))
+
+        assert ":" not in stamp
+        assert "+" not in stamp
+        assert stamp.endswith("Z")
+
+
+def test_save_garmin_data_writes_offset_free_filename(tmp_path):
+    """
+    Generated JSON filenames use the deterministic ``Z`` stamp with no ``+`` offset, so
+    the processor's filename patterns never reject them.
+    """
+    extractor = GarminExtractor(
+        start_date=date(2025, 1, 1),
+        end_date=date(2025, 1, 1),
+        ingest_dir=tmp_path,
+        data_types=("STEPS",),
+    )
+    extractor.user_id = "1"
+
+    paths = extractor._save_garmin_data(
+        {"value": 1}, GARMIN_DATA_REGISTRY.get_by_name("STEPS"), date(2025, 1, 1)
+    )
+
+    name = paths[0].name
+    assert name == "1_STEPS_2025-01-01T12-00-00Z.json"
+    assert "+" not in name
+    assert ":" not in name

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -177,6 +177,26 @@ def _seed_activity(
 FIT_FILENAME = "1_ACTIVITY_12345_2024-01-01T08:00:00Z.fit"
 
 
+class TestParseFilenameLegacyOffset:
+    """
+    Recovery coverage for legacy filenames written with a UTC ``+00-00`` offset.
+    """
+
+    def test_accepts_legacy_utc_offset(self, processor):
+        """
+        Files stamped by a pre-2.14.1 extractor on pendulum 2.x carry a ``+00-00``
+        offset; they must still parse so they can be recovered from quarantine.
+        """
+        parsed = processor._parse_filename("1_STEPS_2026-08-15T12-00-00+00-00.json")
+
+        assert parsed == {
+            "user_id": "1",
+            "data_type": "STEPS",
+            "timestamp": "2026-08-15T12-00-00+00-00",
+            "file_extension": "json",
+        }
+
+
 # --- FIT file processing tests ---------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Fixes the filename bug reported in #83 at its root, so it cannot recur across `pendulum` versions, and folds in that PR's processor-side tolerance for recovery.

## The bug

The extractor stamped every filename with `pendulum.instance(midday_dt, tz="UTC").to_iso8601_string()`. That call's rendering of a UTC instant is **not stable across `pendulum` major versions**:

- pendulum **3.x** &rarr; `2026-08-15T12:00:00Z` &rarr; on disk `...T12-00-00Z` (after the blanket `:`&rarr;`-` swap)
- pendulum **2.x** &rarr; `2026-08-15T12:00:00+00:00` &rarr; on disk `...T12-00-00+00-00`

The processor's three filename patterns accepted `Z` but not `+`, so on any environment that resolved `pendulum` 2.x, **every** extracted JSON/FIT/TCX file failed `_parse_filename` and was routed to quarantine, leaving an empty database. The offset is always UTC (`+00:00`) because all filename paths force `tz="UTC"`; it is never a local zone (correcting the "Europe/Berlin +02:00" framing in #83).

## The fix

- Filenames are now built by a single `_utc_midday_stamp()` helper as a fixed, colon-free, `Z`-suffixed `YYYY-MM-DDT12-00-00Z` string that does **not** depend on the installed `pendulum` version. The fragile whole-filename `.replace(":", "-")` is removed.
- On `pendulum` 3.x the produced names are **byte-identical** to before, so existing databases and file grouping are unaffected. Only the broken 2.x output changes (`+00-00` &rarr; `Z`).
- For recovery of files already quarantined by an affected install, the processor's three filename patterns **also still accept** the legacy `+00-00` offset form (this is #83's change, kept as defense-in-depth): move those files back into the ingest directory and re-run to load them.

## Tests

- `TestUtcMiddayStamp` locks the deterministic format (exact string; asserts no `:`, no `+`, ends in `Z`). This fails if anyone reverts to `to_iso8601_string()` on pendulum 2.x.
- `test_save_garmin_data_writes_offset_free_filename` asserts the end-to-end generated JSON filename.
- `TestParseFilenameLegacyOffset` asserts legacy `+00-00` filenames still parse (recovery path).
- Full suite: 450 passed, 1 skipped.

Releases **2.14.1** (CHANGELOG updated).

Supersedes #83.
