### PR TITLE
feat(auth): manual browser-ticket login for Cloudflare-blocked auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The data lives in a single SQLite file (default `./garmin_data.db`). Query it wi
 
 | Command | What it does | Section |
 |---|---|---|
-| [`garmin auth`](#garmin-auth) | Log into Garmin Connect and store OAuth tokens. Run once per account. | [auth](#garmin-auth) |
+| [`garmin auth`](#garmin-auth) | Log into Garmin Connect and store OAuth tokens. Run once per account; falls back to a manual browser-ticket login when Cloudflare blocks the automated login. | [auth](#garmin-auth) |
 | [`garmin extract`](#garmin-extract) | Download data from Garmin Connect and load it into the SQLite database. The default workflow. Supports rolling-window auto retention via opt-in flags. | [extract](#garmin-extract) |
 | [`garmin info`](#garmin-info) | Show row counts, last-update dates, and DB size. Read-only. | [info](#garmin-info) |
 | [`garmin verify`](#garmin-verify) | Check schema integrity and run SQLite's `PRAGMA integrity_check`. Read-only. | [verify](#garmin-verify) |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ All discovered accounts are extracted sequentially when running `garmin extract`
 
 > Login strategies, token rotation, and the 30-45s anti-rate-limit pause: see [Reference](#reference).
 
+#### Manual login (Cloudflare fallback)
+
+Garmin guards its login endpoints with Cloudflare, which can block the automated `garmin auth` entirely (repeated `403` / `429` errors, ending in "Authentication failed"). When that happens, log in with a ticket captured from your own browser, which passes Cloudflare because it is a real, human session. In an interactive terminal a normal `garmin auth` offers this fallback automatically after the automated login fails; you can also invoke it directly:
+
+```bash
+garmin auth --manual
+```
+
+It prints a short set of steps:
+
+1. Log into Garmin Connect in your browser (any normal login).
+2. Open the URL it gives you in that same browser — you'll land on a page titled "Success".
+3. Open the browser console (Cmd+Opt+J on Chrome, or Ctrl+Shift+J), paste the one-line snippet it gives you, and press Enter. It copies a login ticket to your clipboard.
+4. Paste the ticket back into the terminal.
+
+The tool exchanges that ticket for OAuth tokens and saves them exactly like a normal login, so they still auto-refresh for ~30 days (this is roughly a monthly step, not per-run). Tickets are single-use and expire in about a minute, so paste promptly; if it fails, mint a fresh one. For scripting, pass the ticket (or the full redirect URL that contains it) directly:
+
+```bash
+garmin auth --ticket 'ST-....-cas'
+```
+
 ### Extracting data
 
 ```bash
@@ -284,7 +305,7 @@ garmin auth
 garmin auth --email user@example.com --password '...'
 ```
 
-Performs a fresh interactive login and stores OAuth tokens in `~/.garminconnect/<user_id>/`. Run once per Garmin Connect account; tokens auto-refresh as long as you extract at least once every 30 days. The `--email` / `--password` flags can also be supplied via the `GARMIN_EMAIL` / `GARMIN_PASSWORD` environment variables. See the [Authentication internals](#authentication-internals) collapsible below for the login-strategy waterfall and the 30-45s anti-rate-limit pause explanation.
+Performs a fresh interactive login and stores OAuth tokens in `~/.garminconnect/<user_id>/`. Run once per Garmin Connect account; tokens auto-refresh as long as you extract at least once every 30 days. The `--email` / `--password` flags can also be supplied via the `GARMIN_EMAIL` / `GARMIN_PASSWORD` environment variables. If Garmin's Cloudflare protection blocks the automated login, `--manual` runs a browser-ticket fallback that prints step-by-step capture instructions, and `--ticket 'ST-...'` (a raw service ticket or the full redirect URL that carries it) performs the exchange non-interactively; see [Manual login (Cloudflare fallback)](#manual-login-cloudflare-fallback). See the [Authentication internals](#authentication-internals) collapsible below for the login-strategy waterfall and the 30-45s anti-rate-limit pause explanation.
 
 ### `garmin extract`
 

--- a/garmin_health_data/auth.py
+++ b/garmin_health_data/auth.py
@@ -8,10 +8,21 @@ Authentication (MFA) support.
 import os
 import sys
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
+from urllib.parse import parse_qs, urlparse, urlunparse
 
 import click
 from garmin_health_data.garmin_client import GarminClient
+
+# Manual-ticket bootstrap constants (workaround for the Cloudflare-blocked
+# automated login). The mobile-app service is used to mint the ticket because a
+# browser never validates (consumes) that service's ticket, so it stays usable
+# for the DI token exchange. See the ``garmin auth --manual`` flow.
+MANUAL_SERVICE_URL = "https://mobile.integration.garmin.com/gcm/android"
+MANUAL_MINT_URL = (
+    "https://sso.garmin.com/sso/signin"
+    "?service=https%3A%2F%2Fmobile.integration.garmin.com%2Fgcm%2Fandroid"
+)
 
 
 def get_credentials() -> Tuple[str, str]:
@@ -155,6 +166,174 @@ def discover_accounts(
     )
 
 
+def _save_client_tokens(
+    garmin: GarminClient, base_path: Path, silent: bool = False
+) -> str:
+    """
+    Persist a logged-in client's tokens under ``base_path/<user_id>/``.
+
+    Auto-detects the Garmin user ID from the profile, creates the per-account
+    subdirectory with restrictive permissions, and writes ``garmin_tokens.json``.
+
+    :param garmin: Authenticated Garmin client (DI tokens already set).
+    :param base_path: Base directory for per-account token storage.
+    :param silent: If True, suppress non-essential output.
+    :return: The authenticated Garmin user ID as a string.
+    :raises RuntimeError: If the user ID cannot be read from the profile.
+    """
+    user_id = garmin.get_user_profile().get("id")
+    if not user_id:
+        raise RuntimeError(
+            "Could not determine user ID from Garmin profile. "
+            "The 'id' field was missing from get_user_profile() response."
+        )
+
+    if not silent:
+        click.echo(f"👤 Detected user ID: {user_id}")
+        click.echo("💾 Saving authentication tokens...")
+
+    # Ensure base and per-account token directories exist with proper permissions.
+    base_path.mkdir(parents=True, exist_ok=True)
+    if sys.platform != "win32":
+        base_path.chmod(0o700)
+
+    token_path = base_path / str(user_id)
+    token_path.mkdir(exist_ok=True)
+    if sys.platform != "win32":
+        token_path.chmod(0o700)
+
+    # dump() writes garmin_tokens.json with 0o600 from creation time.
+    garmin.dump(str(token_path))
+
+    if not silent:
+        click.echo()
+        click.secho("✅ Tokens successfully saved!", fg="green", bold=True)
+        click.echo(f"   User ID:  {user_id}")
+        click.echo(f"   Location: {token_path}")
+
+    return str(user_id)
+
+
+def _parse_manual_ticket(raw: str) -> Tuple[str, str]:
+    """
+    Parse a pasted manual-login value into a ticket and its service URL.
+
+    Accepts either a bare ``ST-...`` service ticket (in which case the default mobile
+    service URL is assumed) or the full redirect URL that carries the ticket in its
+    ``ticket`` query parameter.
+
+    :param raw: Raw ``ST-...`` ticket or a full redirect URL.
+    :return: Tuple of (ticket, service_url).
+    :raises click.ClickException: If no ticket can be extracted.
+    """
+    raw = raw.strip()
+    if raw.startswith("ST-"):
+        return raw, MANUAL_SERVICE_URL
+
+    parsed = urlparse(raw)
+    ticket = parse_qs(parsed.query).get("ticket", [None])[0]
+    if not ticket:
+        raise click.ClickException(
+            "No ticket found. Paste the 'ST-...' value or the full URL that "
+            "contains 'ticket=ST-...'."
+        )
+    # The service URL is the redirect target without its query/fragment.
+    service_url = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+    return ticket, service_url
+
+
+def bootstrap_from_ticket(
+    ticket_input: str,
+    base_token_dir: str = "~/.garminconnect",
+    service_url: Optional[str] = None,
+    silent: bool = False,
+) -> str:
+    """
+    Exchange a browser-captured CAS service ticket for DI tokens and save them.
+
+    Bypasses the Cloudflare-blocked automated login: the user obtains a ticket from
+    a real, already-authenticated browser session (which passes Cloudflare) and
+    provides it here. The resulting DI tokens auto-refresh for ~30 days, so this is
+    roughly a monthly step rather than a per-run one.
+
+    :param ticket_input: Raw ``ST-...`` ticket or the full redirect URL carrying it.
+    :param base_token_dir: Base directory for per-account token storage.
+    :param service_url: SSO service the ticket was minted for. Defaults to the value
+        parsed from ``ticket_input`` (or the mobile service for a bare ticket).
+    :param silent: If True, suppress non-essential output.
+    :return: The authenticated Garmin user ID as a string.
+    :raises click.ClickException: If the ticket exchange fails.
+    """
+    ticket, parsed_service = _parse_manual_ticket(ticket_input)
+    service = service_url or parsed_service
+    base_path = Path(base_token_dir).expanduser()
+
+    garmin = GarminClient()
+    try:
+        garmin._exchange_service_ticket(ticket, service_url=service)
+    except Exception as e:
+        raise click.ClickException(
+            f"Ticket exchange failed: {e}. The ticket may be expired or already "
+            "used (they are single-use and last ~1 minute). Mint a fresh one and "
+            "paste it right away."
+        )
+
+    return _save_client_tokens(garmin, base_path, silent=silent)
+
+
+def _print_manual_instructions() -> None:
+    """
+    Print step-by-step instructions for capturing a login ticket from the browser.
+    """
+    # Console/bookmarklet snippet: read the ticket out of the SSO "Success" page
+    # HTML (same-origin) and copy it to the clipboard via the devtools copy() helper.
+    snippet = r"copy(document.documentElement.outerHTML.match(/ST-[\w.-]+/)[0])"
+
+    click.echo()
+    click.secho("🔑 Manual authentication (browser ticket)", fg="cyan", bold=True)
+    click.echo(
+        "Garmin's Cloudflare protection blocks automated login. Grab a login "
+        "ticket from your own browser instead:"
+    )
+    click.echo()
+    click.echo("  1. Log into Garmin Connect in your browser (any normal login).")
+    click.echo(
+        "  2. Open this URL in that same browser. You'll land on a page titled "
+        '"Success":'
+    )
+    click.echo()
+    click.secho(f"     {MANUAL_MINT_URL}", fg="blue")
+    click.echo()
+    click.echo(
+        "  3. Open the browser console (Cmd+Opt+J on Chrome, or Ctrl+Shift+J), "
+        "paste this line, and press Enter."
+    )
+    click.echo("     It copies the ticket to your clipboard:")
+    click.echo()
+    click.secho(f"     {snippet}", fg="green")
+    click.echo()
+    click.echo("  4. Paste the ticket below (it is single-use and expires quickly).")
+    click.echo()
+
+
+def manual_auth(base_token_dir: str = "~/.garminconnect", silent: bool = False) -> str:
+    """
+    Run the interactive manual-ticket login flow.
+
+    Prints capture instructions, prompts for the pasted ticket, and exchanges it.
+
+    :param base_token_dir: Base directory for per-account token storage.
+    :param silent: If True, suppress the instructional output.
+    :return: The authenticated Garmin user ID as a string.
+    """
+    if not silent:
+        _print_manual_instructions()
+    ticket_input = click.prompt("   Ticket (ST-... or full URL)", type=str)
+    return bootstrap_from_ticket(
+        ticket_input, base_token_dir=base_token_dir, silent=silent
+    )
+
+
 def refresh_tokens(
     email: str,
     password: str,
@@ -208,36 +387,10 @@ def refresh_tokens(
                     bold=True,
                 )
 
-        # Auto-detect user ID from profile.
-        user_id = garmin.get_user_profile().get("id")
-        if not user_id:
-            raise RuntimeError(
-                "Could not determine user ID from Garmin profile. "
-                "The 'id' field was missing from get_user_profile() response."
-            )
+        # Persist tokens under a per-account subdirectory.
+        _save_client_tokens(garmin, base_path, silent=silent)
 
         if not silent:
-            click.echo(f"👤 Detected user ID: {user_id}")
-            click.echo("💾 Saving authentication tokens...")
-
-        # Ensure base and per-account token directories exist with proper permissions.
-        base_path.mkdir(parents=True, exist_ok=True)
-        if sys.platform != "win32":
-            base_path.chmod(0o700)
-
-        token_path = base_path / str(user_id)
-        token_path.mkdir(exist_ok=True)
-        if sys.platform != "win32":
-            token_path.chmod(0o700)
-
-        # dump() writes garmin_tokens.json with 0o600 from creation time.
-        garmin.dump(str(token_path))
-
-        if not silent:
-            click.echo()
-            click.secho("✅ Tokens successfully saved!", fg="green", bold=True)
-            click.echo(f"   User ID:  {user_id}")
-            click.echo(f"   Location: {token_path}")
             click.echo()
             click.secho(
                 "🎉 Success! You're authenticated with Garmin Connect", fg="green"

--- a/garmin_health_data/auth.py
+++ b/garmin_health_data/auth.py
@@ -237,6 +237,11 @@ def _parse_manual_ticket(raw: str) -> Tuple[str, str]:
             "No ticket found. Paste the 'ST-...' value or the full URL that "
             "contains 'ticket=ST-...'."
         )
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise click.ClickException(
+            "Could not read a service URL from the pasted value. Paste the bare "
+            "'ST-...' ticket, or the full 'https://...' redirect URL that carries it."
+        )
     # The service URL is the redirect target without its query/fragment.
     service_url = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
     return ticket, service_url
@@ -262,7 +267,7 @@ def bootstrap_from_ticket(
         parsed from ``ticket_input`` (or the mobile service for a bare ticket).
     :param silent: If True, suppress non-essential output.
     :return: The authenticated Garmin user ID as a string.
-    :raises click.ClickException: If the ticket exchange fails.
+    :raises click.ClickException: If the ticket exchange or the token save fails.
     """
     ticket, parsed_service = _parse_manual_ticket(ticket_input)
     service = service_url or parsed_service
@@ -271,14 +276,20 @@ def bootstrap_from_ticket(
     garmin = GarminClient()
     try:
         garmin._exchange_service_ticket(ticket, service_url=service)
+    except click.Abort:
+        # Let user interrupts propagate rather than masking them as a failure.
+        raise
     except Exception as e:
         raise click.ClickException(
             f"Ticket exchange failed: {e}. The ticket may be expired or already "
             "used (they are single-use and last ~1 minute). Mint a fresh one and "
             "paste it right away."
-        )
+        ) from e
 
-    return _save_client_tokens(garmin, base_path, silent=silent)
+    try:
+        return _save_client_tokens(garmin, base_path, silent=silent)
+    except RuntimeError as e:
+        raise click.ClickException(str(e)) from e
 
 
 def _print_manual_instructions() -> None:

--- a/garmin_health_data/auth.py
+++ b/garmin_health_data/auth.py
@@ -9,7 +9,7 @@ import os
 import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qs, urlparse, urlunparse
 
 import click
 from garmin_health_data.garmin_client import GarminClient
@@ -231,8 +231,7 @@ def _parse_manual_ticket(raw: str) -> Tuple[str, str]:
         return raw, MANUAL_SERVICE_URL
 
     parsed = urlparse(raw)
-    query_params = parse_qs(parsed.query)
-    ticket = query_params.get("ticket", [None])[0]
+    ticket = parse_qs(parsed.query).get("ticket", [None])[0]
     if not ticket:
         raise click.ClickException(
             "No ticket found. Paste the 'ST-...' value or the full URL that "
@@ -244,13 +243,16 @@ def _parse_manual_ticket(raw: str) -> Tuple[str, str]:
             "'ST-...' ticket, or the full 'https://...' redirect URL that carries it."
         )
     # Rebuild the service URL as the redirect target with only the ``ticket``
-    # param removed. A CAS ticket is bound to the exact service URL, so any other
-    # query params that were part of it must be preserved for the exchange.
-    service_query = urlencode(
-        {k: v for k, v in query_params.items() if k != "ticket"}, doseq=True
+    # param removed, preserving the exact original encoding and order of any
+    # remaining params. A CAS ticket is bound to the exact service-URL string, so
+    # re-encoding the query (parse + urlencode) could invalidate the exchange.
+    remaining_query = "&".join(
+        part
+        for part in parsed.query.split("&")
+        if part and not part.startswith("ticket=")
     )
     service_url = urlunparse(
-        (parsed.scheme, parsed.netloc, parsed.path, "", service_query, "")
+        (parsed.scheme, parsed.netloc, parsed.path, "", remaining_query, "")
     )
     return ticket, service_url
 

--- a/garmin_health_data/auth.py
+++ b/garmin_health_data/auth.py
@@ -9,7 +9,7 @@ import os
 import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
-from urllib.parse import parse_qs, urlparse, urlunparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import click
 from garmin_health_data.garmin_client import GarminClient
@@ -231,7 +231,8 @@ def _parse_manual_ticket(raw: str) -> Tuple[str, str]:
         return raw, MANUAL_SERVICE_URL
 
     parsed = urlparse(raw)
-    ticket = parse_qs(parsed.query).get("ticket", [None])[0]
+    query_params = parse_qs(parsed.query)
+    ticket = query_params.get("ticket", [None])[0]
     if not ticket:
         raise click.ClickException(
             "No ticket found. Paste the 'ST-...' value or the full URL that "
@@ -242,8 +243,15 @@ def _parse_manual_ticket(raw: str) -> Tuple[str, str]:
             "Could not read a service URL from the pasted value. Paste the bare "
             "'ST-...' ticket, or the full 'https://...' redirect URL that carries it."
         )
-    # The service URL is the redirect target without its query/fragment.
-    service_url = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+    # Rebuild the service URL as the redirect target with only the ``ticket``
+    # param removed. A CAS ticket is bound to the exact service URL, so any other
+    # query params that were part of it must be preserved for the exchange.
+    service_query = urlencode(
+        {k: v for k, v in query_params.items() if k != "ticket"}, doseq=True
+    )
+    service_url = urlunparse(
+        (parsed.scheme, parsed.netloc, parsed.path, "", service_query, "")
+    )
     return ticket, service_url
 
 
@@ -288,8 +296,10 @@ def bootstrap_from_ticket(
 
     try:
         return _save_client_tokens(garmin, base_path, silent=silent)
-    except RuntimeError as e:
-        raise click.ClickException(str(e)) from e
+    except (RuntimeError, OSError) as e:
+        # Missing profile id (RuntimeError) or a filesystem failure while writing
+        # tokens (OSError) should exit cleanly, not dump a traceback.
+        raise click.ClickException(f"Could not save tokens: {e}") from e
 
 
 def _print_manual_instructions() -> None:

--- a/garmin_health_data/cli.py
+++ b/garmin_health_data/cli.py
@@ -4,6 +4,7 @@ Command-line interface for garmin-health-data.
 
 import logging
 import re
+import sys
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -14,8 +15,10 @@ from sqlalchemy import text
 
 from garmin_health_data.__version__ import __version__
 from garmin_health_data.auth import (
+    bootstrap_from_ticket,
     ensure_authenticated,
     get_credentials,
+    manual_auth,
     refresh_tokens,
 )
 from garmin_health_data.constants import GARMIN_DATA_REGISTRY, GARMIN_FILE_TYPES
@@ -95,6 +98,18 @@ def cli(ctx: click.Context):
         ctx.exit(0)
 
 
+def _is_interactive() -> bool:
+    """
+    Report whether stdin is an interactive terminal.
+
+    Wraps ``sys.stdin.isatty()`` in a helper so the manual-login fallback can be
+    exercised in tests without depending on the test runner's stdin handling.
+
+    :return: True when attached to an interactive terminal, False otherwise.
+    """
+    return sys.stdin.isatty()
+
+
 @cli.command()
 @click.option(
     "--email",
@@ -106,10 +121,43 @@ def cli(ctx: click.Context):
     envvar="GARMIN_PASSWORD",
     help="Garmin Connect password (or set GARMIN_PASSWORD env var)",
 )
-def auth(email: Optional[str], password: Optional[str]):
+@click.option(
+    "--manual",
+    is_flag=True,
+    help=(
+        "Log in with a browser-captured ticket instead of email/password. Use "
+        "when Cloudflare blocks the automated login."
+    ),
+)
+@click.option(
+    "--ticket",
+    default=None,
+    help=(
+        "CAS service ticket (ST-...) or full redirect URL, for non-interactive "
+        "manual login. Implies --manual."
+    ),
+)
+def auth(
+    email: Optional[str],
+    password: Optional[str],
+    manual: bool,
+    ticket: Optional[str],
+):
     """
     Authenticate with Garmin Connect and save tokens.
+
+    By default this logs in with your email and password. If Garmin's Cloudflare
+    protection blocks that (repeated 403/429 errors), use --manual to log in with a
+    ticket captured from your own browser session.
     """
+    # Manual browser-ticket bootstrap (Cloudflare-blocked login workaround).
+    if ticket:
+        bootstrap_from_ticket(ticket)
+        return
+    if manual:
+        manual_auth()
+        return
+
     if email and password:
         # Use provided credentials.
         click.echo("Using provided credentials...")
@@ -117,7 +165,24 @@ def auth(email: Optional[str], password: Optional[str]):
         # Prompt for credentials.
         email, password = get_credentials()
 
-    refresh_tokens(email, password)
+    try:
+        refresh_tokens(email, password)
+    except click.ClickException:
+        # Automated login failed (often Garmin's Cloudflare protection). Offer the
+        # browser-ticket fallback interactively; in a non-interactive run there is
+        # nothing to paste into, so point the user at the manual flow and re-raise.
+        if not _is_interactive():
+            click.secho(
+                "💡 Automated login failed. Re-run interactively with:  "
+                "garmin auth --manual",
+                fg="yellow",
+                bold=True,
+            )
+            raise
+        if click.confirm("\nTry manual browser-ticket login now?", default=True):
+            manual_auth()
+        else:
+            raise
 
 
 @cli.command()

--- a/garmin_health_data/cli.py
+++ b/garmin_health_data/cli.py
@@ -151,7 +151,7 @@ def auth(
     ticket captured from your own browser session.
     """
     # Manual browser-ticket bootstrap (Cloudflare-blocked login workaround).
-    if ticket:
+    if ticket is not None:
         bootstrap_from_ticket(ticket)
         return
     if manual:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "garmin-health-data"
-version = "2.14.1"
+version = "2.15.0"
 description = "Download Garmin Connect health data as local files and load it into a SQLite database for analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_auth_manual.py
+++ b/tests/test_auth_manual.py
@@ -60,6 +60,20 @@ class TestParseManualTicket:
         with pytest.raises(click.ClickException):
             _parse_manual_ticket("https://connect.garmin.com/app")
 
+    def test_schemeless_url_with_ticket_raises(self) -> None:
+        """
+        A URL missing its http(s) scheme cannot yield a service URL and raises.
+        """
+        with pytest.raises(click.ClickException):
+            _parse_manual_ticket("connect.garmin.com/app?ticket=ST-9-sso")
+
+    def test_empty_string_raises(self) -> None:
+        """
+        An empty value raises a ClickException rather than being mis-parsed.
+        """
+        with pytest.raises(click.ClickException):
+            _parse_manual_ticket("")
+
 
 class TestBootstrapFromTicket:
     """
@@ -155,7 +169,7 @@ class TestBootstrapFromTicket:
         tmp_path: Path,
     ) -> None:
         """
-        A profile response without an id raises RuntimeError.
+        A profile response without an id surfaces as a clean ClickException.
 
         :param mock_echo: Mock click.echo function.
         :param mock_garmin_class: Mock Garmin client class.
@@ -165,7 +179,7 @@ class TestBootstrapFromTicket:
         mock_garmin.get_user_profile.return_value = {}
         mock_garmin_class.return_value = mock_garmin
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(click.ClickException):
             bootstrap_from_ticket("ST-abc-cas", base_token_dir=str(tmp_path))
 
 

--- a/tests/test_auth_manual.py
+++ b/tests/test_auth_manual.py
@@ -1,0 +1,319 @@
+"""
+Tests for the manual browser-ticket authentication bootstrap.
+
+Covers ticket/URL parsing, the DI-token exchange bootstrap, the interactive manual login
+flow, and CLI routing for the ``--manual`` / ``--ticket`` options used when Cloudflare
+blocks the automated email/password login.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from garmin_health_data.auth import (
+    MANUAL_SERVICE_URL,
+    _parse_manual_ticket,
+    bootstrap_from_ticket,
+    manual_auth,
+)
+from garmin_health_data.cli import auth
+
+
+class TestParseManualTicket:
+    """
+    Test class for parsing pasted manual-login values.
+    """
+
+    def test_bare_ticket_uses_default_service(self) -> None:
+        """
+        A raw ST- ticket returns the default mobile service URL.
+        """
+        ticket, service = _parse_manual_ticket("ST-123-cas")
+        assert ticket == "ST-123-cas"
+        assert service == MANUAL_SERVICE_URL
+
+    def test_bare_ticket_strips_whitespace(self) -> None:
+        """
+        Surrounding whitespace is trimmed from a bare ticket.
+        """
+        ticket, service = _parse_manual_ticket("  ST-123-cas\n")
+        assert ticket == "ST-123-cas"
+        assert service == MANUAL_SERVICE_URL
+
+    def test_full_url_parses_ticket_and_service(self) -> None:
+        """
+        A full redirect URL yields the ticket and the service URL (without query).
+        """
+        ticket, service = _parse_manual_ticket(
+            "https://connect.garmin.com/app?ticket=ST-9-sso"
+        )
+        assert ticket == "ST-9-sso"
+        assert service == "https://connect.garmin.com/app"
+
+    def test_url_without_ticket_raises(self) -> None:
+        """
+        A URL with no ticket parameter raises a ClickException.
+        """
+        with pytest.raises(click.ClickException):
+            _parse_manual_ticket("https://connect.garmin.com/app")
+
+
+class TestBootstrapFromTicket:
+    """
+    Test class for the ticket-to-token bootstrap.
+    """
+
+    @patch("garmin_health_data.auth.GarminClient")
+    @patch("click.echo")
+    def test_success_saves_tokens(
+        self,
+        mock_echo: MagicMock,
+        mock_garmin_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """
+        A successful exchange saves tokens under a per-account subdirectory.
+
+        :param mock_echo: Mock click.echo function.
+        :param mock_garmin_class: Mock Garmin client class.
+        :param tmp_path: Per-test token directory.
+        """
+        mock_garmin = MagicMock()
+        mock_garmin.get_user_profile.return_value = {"id": "12345678"}
+        mock_garmin_class.return_value = mock_garmin
+
+        user_id = bootstrap_from_ticket("ST-abc-cas", base_token_dir=str(tmp_path))
+
+        assert user_id == "12345678"
+        mock_garmin._exchange_service_ticket.assert_called_once_with(
+            "ST-abc-cas", service_url=MANUAL_SERVICE_URL
+        )
+        mock_garmin.dump.assert_called_once()
+        assert (tmp_path / "12345678").is_dir()
+
+    @patch("garmin_health_data.auth.GarminClient")
+    @patch("click.echo")
+    def test_full_url_uses_parsed_service(
+        self,
+        mock_echo: MagicMock,
+        mock_garmin_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """
+        A pasted full URL exchanges against the service parsed from that URL.
+
+        :param mock_echo: Mock click.echo function.
+        :param mock_garmin_class: Mock Garmin client class.
+        :param tmp_path: Per-test token directory.
+        """
+        mock_garmin = MagicMock()
+        mock_garmin.get_user_profile.return_value = {"id": "42"}
+        mock_garmin_class.return_value = mock_garmin
+
+        bootstrap_from_ticket(
+            "https://connect.garmin.com/app?ticket=ST-9-sso",
+            base_token_dir=str(tmp_path),
+        )
+
+        mock_garmin._exchange_service_ticket.assert_called_once_with(
+            "ST-9-sso", service_url="https://connect.garmin.com/app"
+        )
+
+    @patch("garmin_health_data.auth.GarminClient")
+    @patch("click.echo")
+    def test_exchange_failure_raises_clickexception(
+        self,
+        mock_echo: MagicMock,
+        mock_garmin_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """
+        A failed exchange raises ClickException and does not save tokens.
+
+        :param mock_echo: Mock click.echo function.
+        :param mock_garmin_class: Mock Garmin client class.
+        :param tmp_path: Per-test token directory.
+        """
+        mock_garmin = MagicMock()
+        mock_garmin._exchange_service_ticket.side_effect = RuntimeError("boom")
+        mock_garmin_class.return_value = mock_garmin
+
+        with pytest.raises(click.ClickException):
+            bootstrap_from_ticket("ST-abc-cas", base_token_dir=str(tmp_path))
+
+        mock_garmin.dump.assert_not_called()
+
+    @patch("garmin_health_data.auth.GarminClient")
+    @patch("click.echo")
+    def test_missing_user_id_raises(
+        self,
+        mock_echo: MagicMock,
+        mock_garmin_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """
+        A profile response without an id raises RuntimeError.
+
+        :param mock_echo: Mock click.echo function.
+        :param mock_garmin_class: Mock Garmin client class.
+        :param tmp_path: Per-test token directory.
+        """
+        mock_garmin = MagicMock()
+        mock_garmin.get_user_profile.return_value = {}
+        mock_garmin_class.return_value = mock_garmin
+
+        with pytest.raises(RuntimeError):
+            bootstrap_from_ticket("ST-abc-cas", base_token_dir=str(tmp_path))
+
+
+class TestManualAuth:
+    """
+    Test class for the interactive manual login flow.
+    """
+
+    @patch("garmin_health_data.auth.bootstrap_from_ticket", return_value="99")
+    @patch("click.prompt", return_value="ST-xyz-cas")
+    @patch("click.echo")
+    @patch("click.secho")
+    def test_prompts_and_delegates(
+        self,
+        mock_secho: MagicMock,
+        mock_echo: MagicMock,
+        mock_prompt: MagicMock,
+        mock_bootstrap: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """
+        The flow prompts for a ticket and delegates to bootstrap_from_ticket.
+
+        :param mock_secho: Mock click.secho function.
+        :param mock_echo: Mock click.echo function.
+        :param mock_prompt: Mock click.prompt function.
+        :param mock_bootstrap: Mock bootstrap_from_ticket function.
+        :param tmp_path: Per-test token directory.
+        """
+        result = manual_auth(base_token_dir=str(tmp_path))
+
+        assert result == "99"
+        mock_prompt.assert_called_once()
+        mock_bootstrap.assert_called_once_with(
+            "ST-xyz-cas", base_token_dir=str(tmp_path), silent=False
+        )
+
+
+class TestAuthCommandRouting:
+    """
+    Test class for CLI routing of the manual authentication options.
+    """
+
+    @patch("garmin_health_data.cli.bootstrap_from_ticket")
+    def test_ticket_option_routes_to_bootstrap(self, mock_bootstrap: MagicMock) -> None:
+        """
+        ``--ticket`` routes straight to bootstrap_from_ticket without prompting.
+
+        :param mock_bootstrap: Mock bootstrap_from_ticket function.
+        """
+        result = CliRunner().invoke(auth, ["--ticket", "ST-abc-cas"])
+
+        assert result.exit_code == 0
+        mock_bootstrap.assert_called_once_with("ST-abc-cas")
+
+    @patch("garmin_health_data.cli.manual_auth")
+    def test_manual_flag_routes_to_manual_auth(self, mock_manual: MagicMock) -> None:
+        """
+        ``--manual`` routes to the interactive manual_auth flow.
+
+        :param mock_manual: Mock manual_auth function.
+        """
+        result = CliRunner().invoke(auth, ["--manual"])
+
+        assert result.exit_code == 0
+        mock_manual.assert_called_once()
+
+
+class TestAuthAutomatedFallback:
+    """
+    Test class for the manual fallback when automated login fails.
+    """
+
+    @patch("garmin_health_data.cli.manual_auth")
+    @patch(
+        "garmin_health_data.cli.refresh_tokens",
+        side_effect=click.ClickException("Authentication failed"),
+    )
+    @patch("garmin_health_data.cli._is_interactive", return_value=False)
+    def test_noninteractive_failure_prints_hint_and_raises(
+        self,
+        mock_interactive: MagicMock,
+        mock_refresh: MagicMock,
+        mock_manual: MagicMock,
+    ) -> None:
+        """
+        A non-interactive failure prints the --manual hint and does not prompt.
+
+        :param mock_interactive: Mock _is_interactive helper (non-interactive).
+        :param mock_refresh: Mock refresh_tokens raising a ClickException.
+        :param mock_manual: Mock manual_auth function.
+        """
+        result = CliRunner().invoke(auth, ["--email", "a@b.co", "--password", "pw"])
+
+        assert result.exit_code != 0
+        assert "garmin auth --manual" in result.output
+        mock_manual.assert_not_called()
+
+    @patch("garmin_health_data.cli.manual_auth")
+    @patch("click.confirm", return_value=True)
+    @patch(
+        "garmin_health_data.cli.refresh_tokens",
+        side_effect=click.ClickException("Authentication failed"),
+    )
+    @patch("garmin_health_data.cli._is_interactive", return_value=True)
+    def test_interactive_failure_confirm_yes_runs_manual(
+        self,
+        mock_interactive: MagicMock,
+        mock_refresh: MagicMock,
+        mock_confirm: MagicMock,
+        mock_manual: MagicMock,
+    ) -> None:
+        """
+        An interactive failure accepted at the prompt runs the manual flow.
+
+        :param mock_interactive: Mock _is_interactive helper (interactive).
+        :param mock_refresh: Mock refresh_tokens raising a ClickException.
+        :param mock_confirm: Mock click.confirm returning True.
+        :param mock_manual: Mock manual_auth function.
+        """
+        result = CliRunner().invoke(auth, ["--email", "a@b.co", "--password", "pw"])
+
+        assert result.exit_code == 0
+        mock_manual.assert_called_once()
+
+    @patch("garmin_health_data.cli.manual_auth")
+    @patch("click.confirm", return_value=False)
+    @patch(
+        "garmin_health_data.cli.refresh_tokens",
+        side_effect=click.ClickException("Authentication failed"),
+    )
+    @patch("garmin_health_data.cli._is_interactive", return_value=True)
+    def test_interactive_failure_confirm_no_raises(
+        self,
+        mock_interactive: MagicMock,
+        mock_refresh: MagicMock,
+        mock_confirm: MagicMock,
+        mock_manual: MagicMock,
+    ) -> None:
+        """
+        An interactive failure declined at the prompt re-raises without manual login.
+
+        :param mock_interactive: Mock _is_interactive helper (interactive).
+        :param mock_refresh: Mock refresh_tokens raising a ClickException.
+        :param mock_confirm: Mock click.confirm returning False.
+        :param mock_manual: Mock manual_auth function.
+        """
+        result = CliRunner().invoke(auth, ["--email", "a@b.co", "--password", "pw"])
+
+        assert result.exit_code != 0
+        mock_manual.assert_not_called()

--- a/tests/test_auth_manual.py
+++ b/tests/test_auth_manual.py
@@ -74,6 +74,16 @@ class TestParseManualTicket:
         with pytest.raises(click.ClickException):
             _parse_manual_ticket("")
 
+    def test_full_url_preserves_non_ticket_params(self) -> None:
+        """
+        Query params other than ``ticket`` are kept in the reconstructed service URL.
+        """
+        ticket, service = _parse_manual_ticket(
+            "https://connect.garmin.com/app?foo=bar&ticket=ST-9-sso"
+        )
+        assert ticket == "ST-9-sso"
+        assert service == "https://connect.garmin.com/app?foo=bar"
+
 
 class TestBootstrapFromTicket:
     """
@@ -177,6 +187,29 @@ class TestBootstrapFromTicket:
         """
         mock_garmin = MagicMock()
         mock_garmin.get_user_profile.return_value = {}
+        mock_garmin_class.return_value = mock_garmin
+
+        with pytest.raises(click.ClickException):
+            bootstrap_from_ticket("ST-abc-cas", base_token_dir=str(tmp_path))
+
+    @patch("garmin_health_data.auth.GarminClient")
+    @patch("click.echo")
+    def test_token_save_oserror_raises_clickexception(
+        self,
+        mock_echo: MagicMock,
+        mock_garmin_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """
+        A filesystem error while saving tokens surfaces as a ClickException.
+
+        :param mock_echo: Mock click.echo function.
+        :param mock_garmin_class: Mock Garmin client class.
+        :param tmp_path: Per-test token directory.
+        """
+        mock_garmin = MagicMock()
+        mock_garmin.get_user_profile.return_value = {"id": "12345678"}
+        mock_garmin.dump.side_effect = OSError("read-only file system")
         mock_garmin_class.return_value = mock_garmin
 
         with pytest.raises(click.ClickException):


### PR DESCRIPTION
## Summary

Garmin's Cloudflare protection can block the automated email/password login outright (repeated 403/429 across every login strategy, ending in "Authentication failed"). This adds a **manual browser-ticket login** that works around it: the user grabs a CAS service ticket from their own already-logged-in browser (which passes Cloudflare because it is a real, human session), and the tool exchanges it for DI tokens.

Verified end-to-end against a live Garmin account: a fresh, unconsumed ticket exchanges successfully on the current client ID, and the resulting tokens auto-refresh for ~30 days as usual.

## What's added

- **`garmin auth --manual`** — interactive flow. Prints the mint URL and a one-line browser-console snippet that copies a ticket to the clipboard, then prompts to paste it.
- **`garmin auth --ticket ST-...`** — non-interactive exchange (raw ticket or the full redirect URL that carries it), for scripting.
- **Automatic fallback** — a plain `garmin auth` that fails the automated login now offers the manual flow: a confirm prompt in an interactive terminal, or a printed "re-run with `--manual`" hint in a non-interactive run (so cron/CI don't hang on a prompt).

## Implementation notes

- Ticket exchange and token persistence reuse the existing DI flow; the per-account token-save logic is extracted into a shared `_save_client_tokens` helper, with no behavior change to the existing `refresh_tokens` path.
- The mint uses the mobile-app service, whose ticket a browser never validates/consumes, so it stays usable for the exchange. A ticket captured from a normal web redirect is single-use and already spent by the time it reaches the tool, which was the root of the false "all client IDs failed" reports (see #86).
- No new dependencies.

## Tests

- New `tests/test_auth_manual.py`: ticket/URL parsing, the exchange bootstrap (success, failure, missing profile id), the interactive flow, CLI routing, and the automated-failure fallback (interactive confirm yes/no, non-interactive hint).
- Full suite: **464 passed, 1 skipped**; black-clean.

Closes #81
