### PR TITLE
feat(activity): capture beat-to-beat HRV (R-R intervals) from FIT files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`activity_hrv` table** ([#89](https://github.com/diegoscarabelli/garmin-health-data/issues/89)): captures raw beat-to-beat R-R interval data (heart rate variability) from the `hrv` message stream in activity FIT files, previously ignored by the parser. Each `hrv` message carries a `time` field: a tuple of up to 5 R-R intervals in seconds, right-padded with nulls. `_process_fit_file` flattens all `hrv` frames for an activity (dropping null padding, preserving recorded order) into one row per activity: `rr_json` (a JSON array, mirroring the `activity_path` precedent) plus a denormalized `interval_count`. Populated via the same delete+insert pattern as the other FIT-derived activity tables, so reprocessing is idempotent; activities without a compatible heart rate source get no row. Stored as text JSON rather than JSONB for portability, consistent with `activity_path`. Distinct from the existing `hrv` table, which holds Garmin's overnight 5-minute sleep HRV summary (milliseconds, keyed by `sleep_id`) — a different signal from a different source with no content overlap. Deliberately kept out of `activity_ts_metric` and therefore untouched by `garmin downsample`/`garmin prune`: averaging R-R intervals into time buckets would collapse them to mean inter-beat time and destroy the successive-beat differences that are the HRV signal. TCX files carry no HRV message stream, so this table is FIT-only.
+
 ## [2.14.1] - 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/user-attachments/assets/65023665-fa7a-4bbf-85d6-c3d4a3145171
 
 ## Features
 
-- 🏥 **Comprehensive data**: a single `garmin extract` command downloads sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics, menstrual cycle, and activity files in FIT or TCX format (time-series, laps, splits) as local files and loads them into a SQLite database in one pass.
+- 🏥 **Comprehensive data**: a single `garmin extract` command downloads sleep, HRV, stress, body battery, heart rate, respiration, VO2 max, training metrics, menstrual cycle, and activity files in FIT or TCX format (time-series, laps, splits, beat-to-beat HRV) as local files and loads them into a SQLite database in one pass.
 - 👥 **Multi-account**: one database across multiple Garmin Connect accounts (e.g. family members). Run `garmin auth` once per account; extraction discovers and processes them automatically.
 - 🛡️ **Resilient pipeline**: four-folder lifecycle (`ingest/process/storage/quarantine`), auto-resume from the last update, crash recovery, and per-date / per-data-type / per-activity / per-FileSet failure isolation. Original files are preserved on disk for offline backup and post-mortem inspection.
 - 🗜️ **Bounded disk usage**: `garmin downsample` aggregates per-second sensor data into time-bucketed records, and `garmin prune` deletes the source rows. Together they let you run a multi-year history without unbounded growth (`activity_ts_metric` is ~93% of typical DB size).
@@ -413,7 +413,7 @@ If all five strategies are exhausted without success (uncommon — typically onl
 
 Duplicates are prevented through a four-tier approach:
 
-1. **Activity metrics from FIT or TCX files** (time-series, laps, splits) **and per-day menstrual cycle tags** (symptoms, moods, discharge): delete+insert pattern. Existing rows are deleted and fresh data re-inserted in the same transaction. For activity metrics this handles added/removed laps or records between reprocesses; the `ts_data_available` flag tracks whether time-series data exists. For menstrual cycle tags, it ensures user-removed symptoms/moods on Garmin Connect propagate to the local DB on the next extract. TCX is parsed for activities uploaded to Garmin Connect from older devices or third-party apps; splits are FIT-only (TCX has no split concept).
+1. **Activity metrics from FIT or TCX files** (time-series, laps, splits, HRV) **and per-day menstrual cycle tags** (symptoms, moods, discharge): delete+insert pattern. Existing rows are deleted and fresh data re-inserted in the same transaction. For activity metrics this handles added/removed laps or records between reprocesses; the `ts_data_available` flag tracks whether time-series data exists. For menstrual cycle tags, it ensures user-removed symptoms/moods on Garmin Connect propagate to the local DB on the next extract. TCX is parsed for activities uploaded to Garmin Connect from older devices or third-party apps; splits and HRV are FIT-only (TCX has no split concept and no HRV message stream).
 2. **JSON wellness time-series** (heart rate, sleep movement, stress, body battery, etc.): `INSERT...ON CONFLICT DO NOTHING` for idempotent upserts.
 3. **Main records** (activities, sleep, user profile, menstrual cycle day, observed menstrual cycle summaries): `INSERT...ON CONFLICT DO UPDATE` to refresh existing records with new data.
 4. **Predicted menstrual cycle summaries** (`menstrual_cycle_summary` rows with `predicted_cycle = TRUE`): wipe-and-replace per extract. Garmin recomputes its projected start dates as new data is logged, so a pure upsert would accumulate stale predicted rows whose `start_date` PK no longer matches the latest projection. The processor `DELETE`s all predicted rows for the user before inserting the new set; observed (logged) cycles use pattern 3 and survive untouched.
@@ -471,7 +471,7 @@ Both `prune` and `downsample` use the same date-range semantics as `extract`:
 
 #### `garmin prune`
 
-Deletes rows from `activity_ts_metric` for activities in range. Activity rows themselves, splits, laps, agg metrics, paths, sleep details, biometric series, and the downsampled buckets table are all preserved. By default, prints the matching row count and prompts before deleting.
+Deletes rows from `activity_ts_metric` for activities in range. Activity rows themselves, splits, laps, agg metrics, paths, HRV R-R interval series, sleep details, biometric series, and the downsampled buckets table are all preserved. By default, prints the matching row count and prompts before deleting.
 
 | Flag | Type | Purpose |
 | --- | --- | --- |
@@ -564,7 +564,7 @@ The command is **idempotent** (a database that already has `parent_activity_id` 
 
 ### Database Schema
 
-The SQLite database contains 39 tables organized by category. The complete schema is defined in [garmin_health_data/tables.ddl](garmin_health_data/tables.ddl) following the same pattern as the [openetl project](https://github.com/diegoscarabelli/openetl). The schema includes inline documentation comments for all tables and columns, which are preserved in the SQLite database itself:
+The SQLite database contains 40 tables organized by category. The complete schema is defined in [garmin_health_data/tables.ddl](garmin_health_data/tables.ddl) following the same pattern as the [openetl project](https://github.com/diegoscarabelli/openetl). The schema includes inline documentation comments for all tables and columns, which are preserved in the SQLite database itself:
 
 ```bash
 # View schema for a specific table
@@ -585,7 +585,7 @@ The database schema has been adapted from the original PostgreSQL/TimescaleDB [s
 - **Converted SERIAL to AUTOINCREMENT** — PostgreSQL `SERIAL` types converted to SQLite `INTEGER PRIMARY KEY AUTOINCREMENT`.
 - **Replaced TimescaleDB hypertables** — time-series tables use regular SQLite tables with indexes on timestamp columns for efficient queries.
 - **SQLite-compatible upsert syntax** — uses SQLite's `INSERT ... ON CONFLICT` for handling duplicate records.
-- **JSON over JSONB** — PostgreSQL `JSONB` columns (e.g., `activity_path.path_json`) are stored in SQLite as `JSON`/TEXT. CHECK constraints rely on SQLite JSON functions (`json_valid`, `json_type`, `json_array_length`). The global SQLite >= 3.35 requirement under [Requirements](#requirements) is necessary but not sufficient: JSON1 functions are enabled by default in modern CPython builds but can be omitted in some custom or stripped-down SQLite builds. If `CREATE TABLE` fails with errors about missing `json_valid` or `json_type`, verify JSON support:
+- **JSON over JSONB** — PostgreSQL `JSONB` columns (e.g., `activity_path.path_json`, `activity_hrv.rr_json`) are stored in SQLite as `JSON`/TEXT. CHECK constraints rely on SQLite JSON functions (`json_valid`, `json_type`, `json_array_length`). The global SQLite >= 3.35 requirement under [Requirements](#requirements) is necessary but not sufficient: JSON1 functions are enabled by default in modern CPython builds but can be omitted in some custom or stripped-down SQLite builds. If `CREATE TABLE` fails with errors about missing `json_valid` or `json_type`, verify JSON support:
 
   ```bash
   python - <<'PY'
@@ -614,10 +614,11 @@ user (root table)
 
 *Foreign keys: `user_profile` → `user.user_id`*
 
-**Activities (12 tables)**
+**Activities (13 tables)**
 
 ```
 activity (main activity records)
+├── activity_hrv (eagerly materialized beat-to-beat R-R interval series as JSON array)
 ├── activity_lap_metric (lap-by-lap metrics)
 ├── activity_path (eagerly materialized GPS path as JSON array)
 ├── activity_split_metric (split data)
@@ -706,7 +707,7 @@ menstrual_cycle_summary (per-cycle summaries: start date, period length, predict
 
 ## Comparison With Other Tools
 
-**[garmin-health-data](https://github.com/diegoscarabelli/garmin-health-data)** is designed for comprehensive data extraction with a well-structured relational schema that supports both human-powered analytics and LLM-powered analysis via agents querying the locally created SQLite file. It extracts complete FIT file data with per-second activity metrics, 1-minute sleep intervals, and sport-specific tables for detailed analysis. The normalized 38-table schema with explicit SQL constraints ensures data integrity and makes it easy to understand relationships for complex queries, power zone analysis, running dynamics, and long-term trend studies.
+**[garmin-health-data](https://github.com/diegoscarabelli/garmin-health-data)** is designed for comprehensive data extraction with a well-structured relational schema that supports both human-powered analytics and LLM-powered analysis via agents querying the locally created SQLite file. It extracts complete FIT file data with per-second activity metrics, 1-minute sleep intervals, and sport-specific tables for detailed analysis. The normalized 40-table schema with explicit SQL constraints ensures data integrity and makes it easy to understand relationships for complex queries, power zone analysis, running dynamics, and long-term trend studies.
 
 **[garmy](https://github.com/bes-dev/garmy)** is optimized for programmatic access to the Garmin Connect API, particularly useful for AI assistant integration via its built-in MCP (Model Context Protocol) server. It enables real-time interaction with Claude Desktop or custom chatbots for quick daily insights and summaries. However, it's limited to API-provided metrics (daily aggregates only, no FIT file access), making deep analytics or granular time-series analysis impossible. Best suited for lightweight health monitoring apps that prioritize AI integration over comprehensive data collection.
 
@@ -725,7 +726,7 @@ Check out [OpenETL's Garmin pipeline](https://github.com/diegoscarabelli/openetl
 | **Sleep data granularity** | ✅ 7 tables, 1-min intervals | ⚠️ 2 tables, less granular | ⚠️ 1 table, daily aggregate | ❌ | ❌ |
 | **FIT file time-series data** | ✅ All metrics (EAV schema) | ⚠️ Limited (~10 core fields) | ❌ API-only (no FIT files) | ❌ | ❌ |
 | **Power meter & advanced metrics** | ✅ Full support | ❌ Not captured | ❌ API limitations | ❌ | ❌ |
-| **Database schema quality** | ✅ Normalized, 38 tables | ⚠️ ~31 tables, mixed normalization | ❌ Very simple | N/A | N/A |
+| **Database schema quality** | ✅ Normalized, 40 tables | ⚠️ ~31 tables, mixed normalization | ❌ Very simple | N/A | N/A |
 | **Duplicate prevention** | ✅ Explicit SQL ON CONFLICT | ⚠️ ORM merge (undocumented) | ✅ ORM merge + sync tracking | N/A | N/A |
 | **Auto-resume** | ✅ | ✅ | ✅ | ✅ | ❌ |
 | **Active maintenance** | ✅ | ✅ | ✅ | ✅ | ⚠️ Limited |

--- a/garmin_health_data/models.py
+++ b/garmin_health_data/models.py
@@ -1118,6 +1118,15 @@ class ActivityHrv(Base, InsertBase):
             "json_valid(rr_json)",
             name="activity_hrv_rr_json_valid",
         ),
+        CheckConstraint(
+            "json_type(rr_json) = 'array'",
+            name="activity_hrv_rr_json_is_array",
+        ),
+        CheckConstraint(
+            "json_array_length(rr_json) = interval_count",
+            name="activity_hrv_interval_count_matches",
+        ),
+        Index("activity_hrv_interval_count_idx", "interval_count"),
     )
 
 

--- a/garmin_health_data/models.py
+++ b/garmin_health_data/models.py
@@ -1089,6 +1089,38 @@ class ActivityPath(Base, InsertBase):
     )
 
 
+class ActivityHrv(Base, InsertBase):
+    """
+    Per-activity beat-to-beat R-R interval series (raw HRV) from activity FIT files.
+
+    Stores the ordered sequence of intervals between consecutive heartbeats in seconds,
+    as recorded by a compatible heart rate source throughout an activity. Distinct from
+    the sleep `HRV` table, which holds Garmin's overnight 5-minute HRV summary in
+    milliseconds keyed by `sleep_id`; this table holds raw beat-to-beat data in seconds
+    keyed by `activity_id`. One row per activity that has HRV data; activities without a
+    compatible HR source have no row. Uses delete+insert in `_process_fit_file` for
+    reprocessing idempotency. TCX files carry no HRV message stream, so this table is
+    populated from FIT files only.
+    """
+
+    __tablename__ = "activity_hrv"
+
+    activity_id = Column(
+        BigInteger,
+        ForeignKey("activity.activity_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    rr_json = Column(JSON, nullable=False)
+    interval_count = Column(Integer, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "json_valid(rr_json)",
+            name="activity_hrv_rr_json_valid",
+        ),
+    )
+
+
 class ActivityTsMetricDownsampled(Base, InsertBase):
     """
     Per-activity time-bucketed aggregates of `activity_ts_metric`.

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -3585,15 +3585,18 @@ class GarminProcessor(Processor):
                     # remaining values are appended in recorded order.
                     elif frame.name == "hrv":
                         for field in frame.fields:
-                            if field.name == "time" and field.value is not None:
-                                try:
-                                    rr_values.extend(
-                                        v for v in field.value if v is not None
-                                    )
-                                except TypeError:
-                                    # Non-iterable `time` value; skip this
-                                    # frame rather than abort the whole file.
-                                    continue
+                            if field.name == "time" and isinstance(
+                                field.value, (tuple, list)
+                            ):
+                                # Keep only numeric R-R intervals: drop the None
+                                # padding and any non-numeric entries, and coerce
+                                # to float for JSON serialization. bool is
+                                # excluded since it is a subclass of int.
+                                for interval in field.value:
+                                    if isinstance(
+                                        interval, (int, float)
+                                    ) and not isinstance(interval, bool):
+                                        rr_values.append(float(interval))
 
         # Convert FIT semicircles to decimal degrees for path materialization.
         gps_records_deg = [

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -3199,7 +3199,9 @@ class GarminProcessor(Processor):
 
         Pass ``split_metrics=None`` for source formats with no split concept (e.g. TCX);
         pass an empty list for formats that have splits but found none in this file.
-        Same convention for ``rr_values`` and formats with no HRV message stream.
+        Same convention for ``rr_values``: ``None`` for source formats with no HRV
+        message stream (e.g. TCX); an empty list for HRV-capable formats (FIT) that
+        found no ``hrv`` frames in this file.
 
         :param activity_id: Activity primary key.
         :param file_path: Source file path, used in log messages only.
@@ -3213,7 +3215,7 @@ class GarminProcessor(Processor):
         :param split_metrics: Split metric instances, or ``None`` if the source format
             has no splits.
         :param rr_values: Beat-to-beat R-R intervals in seconds, in recorded order, or
-            ``None``/empty if the source format or file has no HRV data.
+            ``None`` if the source format has no HRV message stream.
         """
         # Flush so any pending session state settles before bulk delete.
         session.flush()
@@ -3324,25 +3326,27 @@ class GarminProcessor(Processor):
                 fg="blue",
             )
 
-        if rr_values:
-            session.execute(
-                insert(ActivityHrv),
-                [
-                    {
-                        "activity_id": activity_id,
-                        "rr_json": rr_values,
-                        "interval_count": len(rr_values),
-                    }
-                ],
-            )
-            click.echo(f"Processed {len(rr_values)} HRV R-R intervals.")
-        else:
-            # HRV is only present in activities recorded with a compatible
-            # heart rate source, so this is info rather than a warning.
-            click.secho(
-                "ℹ️ No HRV data found, skipping activity_hrv materialization.",
-                fg="blue",
-            )
+        if rr_values is not None:
+            if rr_values:
+                session.execute(
+                    insert(ActivityHrv),
+                    [
+                        {
+                            "activity_id": activity_id,
+                            "rr_json": rr_values,
+                            "interval_count": len(rr_values),
+                        }
+                    ],
+                )
+                click.echo(f"Processed {len(rr_values)} HRV R-R intervals.")
+            else:
+                # HRV is only present in activities recorded with a
+                # compatible heart rate source, so this is info rather than
+                # a warning.
+                click.secho(
+                    "ℹ️ No HRV data found, skipping activity_hrv materialization.",
+                    fg="blue",
+                )
 
     def _process_fit_file(self, file_path: Path, session: Session):
         """
@@ -3835,7 +3839,8 @@ class GarminProcessor(Processor):
         # TCX coordinates are already in decimal degrees, and TCX has no split
         # concept (split_metrics=None suppresses both the insert and the
         # "no split data" warning) and no HRV message stream (rr_values=None
-        # is treated the same as an empty list: an info-level skip message).
+        # suppresses both the insert and the "no HRV data" message, the same
+        # way split_metrics=None does).
         self._persist_activity_metrics(
             activity_id=activity_id,
             file_path=file_path,

--- a/garmin_health_data/processor.py
+++ b/garmin_health_data/processor.py
@@ -34,6 +34,7 @@ from garmin_health_data.constants import (
 from garmin_health_data.models import (
     Acclimation,
     Activity,
+    ActivityHrv,
     ActivityLapMetric,
     ActivityPath,
     ActivitySplitMetric,
@@ -3185,18 +3186,20 @@ class GarminProcessor(Processor):
         gps_records_deg: List[tuple],
         session: Session,
         split_metrics: Optional[List[ActivitySplitMetric]] = None,
+        rr_values: Optional[List[float]] = None,
     ) -> None:
         """
         Persist parsed activity metrics with idempotent delete+insert semantics.
 
-        Replaces all existing ts/split/lap/path rows for ``activity_id`` and bulk-
+        Replaces all existing ts/split/lap/path/hrv rows for ``activity_id`` and bulk-
         inserts the new ones. Coalesces duplicate ts_metrics by ``(timestamp, name)`` to
         avoid UNIQUE-constraint collisions. Materializes ``activity_path`` from
-        ``gps_records_deg`` (sorted by timestamp before insert). Updates
-        ``existing_activity.ts_data_available``.
+        ``gps_records_deg`` (sorted by timestamp before insert) and ``activity_hrv``
+        from ``rr_values``. Updates ``existing_activity.ts_data_available``.
 
         Pass ``split_metrics=None`` for source formats with no split concept (e.g. TCX);
         pass an empty list for formats that have splits but found none in this file.
+        Same convention for ``rr_values`` and formats with no HRV message stream.
 
         :param activity_id: Activity primary key.
         :param file_path: Source file path, used in log messages only.
@@ -3209,6 +3212,8 @@ class GarminProcessor(Processor):
         :param session: SQLAlchemy session.
         :param split_metrics: Split metric instances, or ``None`` if the source format
             has no splits.
+        :param rr_values: Beat-to-beat R-R intervals in seconds, in recorded order, or
+            ``None``/empty if the source format or file has no HRV data.
         """
         # Flush so any pending session state settles before bulk delete.
         session.flush()
@@ -3221,6 +3226,7 @@ class GarminProcessor(Processor):
             ActivitySplitMetric,
             ActivityLapMetric,
             ActivityPath,
+            ActivityHrv,
         ):
             session.execute(
                 delete(model)
@@ -3318,16 +3324,38 @@ class GarminProcessor(Processor):
                 fg="blue",
             )
 
+        if rr_values:
+            session.execute(
+                insert(ActivityHrv),
+                [
+                    {
+                        "activity_id": activity_id,
+                        "rr_json": rr_values,
+                        "interval_count": len(rr_values),
+                    }
+                ],
+            )
+            click.echo(f"Processed {len(rr_values)} HRV R-R intervals.")
+        else:
+            # HRV is only present in activities recorded with a compatible
+            # heart rate source, so this is info rather than a warning.
+            click.secho(
+                "ℹ️ No HRV data found, skipping activity_hrv materialization.",
+                fg="blue",
+            )
+
     def _process_fit_file(self, file_path: Path, session: Session):
         """
         Process a FIT file and extract time-series, split, lap, and GPS path data.
 
-        Processes FIT file using fitdecode library, extracts record, split, and lap
+        Processes FIT file using fitdecode library, extracts record, split, lap, and hrv
         frames, and stores metrics via delete+insert for idempotent reprocessing.
         Activities with GPS samples also get an eagerly materialized `ActivityPath` row
         holding an ordered [lon, lat] array sorted by timestamp, ready for downstream
-        path-layer visualization. Updates `ts_data_available` flag based on whether
-        time-series records were found.
+        path-layer visualization. Activities with a compatible heart rate source also
+        get an eagerly materialized `ActivityHrv` row holding the ordered beat-to-beat
+        R-R interval series in seconds. Updates `ts_data_available` flag based on
+        whether time-series records were found.
 
         :param file_path: Path to the FIT file.
         :param session: SQLAlchemy Session object.
@@ -3376,6 +3404,7 @@ class GarminProcessor(Processor):
         ts_metrics = []
         split_metrics = []
         lap_metrics = []
+        rr_values: List[float] = []
         split_idx = 0
         lap_idx = 0
 
@@ -3546,6 +3575,22 @@ class GarminProcessor(Processor):
                                     # Skip fields that can't be converted to float.
                                     continue
 
+                    # Process hrv frames: beat-to-beat R-R intervals in seconds.
+                    # The `time` field is a tuple of up to 5 R-R intervals,
+                    # right-padded with None; null padding is dropped and the
+                    # remaining values are appended in recorded order.
+                    elif frame.name == "hrv":
+                        for field in frame.fields:
+                            if field.name == "time" and field.value is not None:
+                                try:
+                                    rr_values.extend(
+                                        v for v in field.value if v is not None
+                                    )
+                                except TypeError:
+                                    # Non-iterable `time` value; skip this
+                                    # frame rather than abort the whole file.
+                                    continue
+
         # Convert FIT semicircles to decimal degrees for path materialization.
         gps_records_deg = [
             (
@@ -3565,6 +3610,7 @@ class GarminProcessor(Processor):
             gps_records_deg=gps_records_deg,
             session=session,
             split_metrics=split_metrics,
+            rr_values=rr_values,
         )
 
     def _process_activity_file(self, file_path: Path, session: Session):
@@ -3598,7 +3644,8 @@ class GarminProcessor(Processor):
         activity_lap_metric. Activities with GPS trackpoints also get a materialized
         activity_path row. Uses delete+insert for idempotent reprocessing.
 
-        TCX does not contain split data, so activity_split_metric is not populated.
+        TCX does not contain split data, so activity_split_metric is not populated. TCX
+        also has no HRV message stream, so activity_hrv is not populated.
 
         :param file_path: Path to the TCX file.
         :param session: SQLAlchemy Session object.
@@ -3787,7 +3834,8 @@ class GarminProcessor(Processor):
 
         # TCX coordinates are already in decimal degrees, and TCX has no split
         # concept (split_metrics=None suppresses both the insert and the
-        # "no split data" warning).
+        # "no split data" warning) and no HRV message stream (rr_values=None
+        # is treated the same as an empty list: an info-level skip message).
         self._persist_activity_metrics(
             activity_id=activity_id,
             file_path=file_path,
@@ -3797,4 +3845,5 @@ class GarminProcessor(Processor):
             gps_records_deg=gps_records,
             session=session,
             split_metrics=None,
+            rr_values=None,
         )

--- a/garmin_health_data/tables.ddl
+++ b/garmin_health_data/tables.ddl
@@ -796,6 +796,17 @@ CREATE TABLE IF NOT EXISTS activity_path (
 CREATE INDEX IF NOT EXISTS activity_path_point_count_idx
 ON activity_path (point_count);
 
+-- Per-activity beat-to-beat R-R interval series (raw HRV) extracted from activity FIT files. Stores the ordered sequence of intervals between consecutive heartbeats in seconds, as recorded by a compatible heart rate source during the activity. Distinct from the sleep `hrv` table, which holds Garmin''s overnight 5-minute HRV summary in milliseconds keyed by sleep_id; this table holds raw beat-to-beat data in seconds keyed by activity_id. One row per activity with HRV data; activities without a compatible HR source have no row. TCX files carry no HRV message stream, so this table is populated from FIT files only.
+CREATE TABLE IF NOT EXISTS activity_hrv (
+    activity_id BIGINT NOT NULL          -- References activity(activity_id). One row per activity.
+    , rr_json JSON NOT NULL              -- Ordered array of beat-to-beat R-R intervals in seconds, in recorded order.
+    , interval_count INTEGER NOT NULL    -- Number of R-R intervals in rr_json. Denormalized for cheap filtering.
+    , create_ts DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP  -- Timestamp when the record was created in the database.
+    , PRIMARY KEY (activity_id)
+    , FOREIGN KEY (activity_id) REFERENCES activity (activity_id) ON DELETE CASCADE
+    , CONSTRAINT activity_hrv_rr_json_valid CHECK (JSON_VALID(rr_json))
+);
+
 -- Strength training per-exercise aggregates from Garmin Connect summarizedExerciseSets. Each row represents one exercise type within a strength training activity, capturing sets, reps, volume, duration, and max weight.
 CREATE TABLE IF NOT EXISTS strength_exercise (
     activity_id BIGINT NOT NULL          -- References activity(activity_id). Identifies which activity this exercise belongs to.

--- a/garmin_health_data/tables.ddl
+++ b/garmin_health_data/tables.ddl
@@ -805,7 +805,14 @@ CREATE TABLE IF NOT EXISTS activity_hrv (
     , PRIMARY KEY (activity_id)
     , FOREIGN KEY (activity_id) REFERENCES activity (activity_id) ON DELETE CASCADE
     , CONSTRAINT activity_hrv_rr_json_valid CHECK (JSON_VALID(rr_json))
+    , CONSTRAINT activity_hrv_rr_json_is_array CHECK (JSON_TYPE(rr_json) = 'array')
+    , CONSTRAINT activity_hrv_interval_count_matches CHECK (
+        JSON_ARRAY_LENGTH(rr_json) = interval_count
+    )
 );
+
+CREATE INDEX IF NOT EXISTS activity_hrv_interval_count_idx
+ON activity_hrv (interval_count);
 
 -- Strength training per-exercise aggregates from Garmin Connect summarizedExerciseSets. Each row represents one exercise type within a strength training activity, capturing sets, reps, volume, duration, and max weight.
 CREATE TABLE IF NOT EXISTS strength_exercise (

--- a/tests/test_db_cascade.py
+++ b/tests/test_db_cascade.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 
 from garmin_health_data.models import (
     Activity,
+    ActivityHrv,
     ActivityLapMetric,
     ActivityPath,
     ActivitySplitMetric,
@@ -97,8 +98,8 @@ def test_delete_activity_cascades_to_all_children(
     """
     Deleting an activity removes rows in every activity-child table.
 
-    This exercises all 10 child FKs declared with `ON DELETE CASCADE`, including the new
-    `activity_ts_metric_downsampled` table.
+    This exercises all 12 child FKs declared with `ON DELETE CASCADE`, including
+    `activity_ts_metric_downsampled` and `activity_hrv`.
     """
     activity = _make_activity(activity_id=1001, user_id=seeded_user)
     db_session.add(activity)
@@ -124,6 +125,7 @@ def test_delete_activity_cascades_to_all_children(
                 activity_id=1001, lap_idx=1, name="distance", value=100.0
             ),
             ActivityPath(activity_id=1001, path_json=[], point_count=0),
+            ActivityHrv(activity_id=1001, rr_json=[0.5, 0.51], interval_count=2),
             StrengthExercise(
                 activity_id=1001,
                 exercise_category="BENCH_PRESS",
@@ -152,6 +154,7 @@ def test_delete_activity_cascades_to_all_children(
         ActivitySplitMetric,
         ActivityLapMetric,
         ActivityPath,
+        ActivityHrv,
         StrengthExercise,
         StrengthSet,
         ActivityTsMetricDownsampled,
@@ -172,6 +175,7 @@ def test_delete_activity_cascades_to_all_children(
         ActivitySplitMetric,
         ActivityLapMetric,
         ActivityPath,
+        ActivityHrv,
         StrengthExercise,
         StrengthSet,
         ActivityTsMetricDownsampled,

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 from garmin_health_data.models import (
     HRV,
     Activity,
+    ActivityHrv,
     ActivityLapMetric,
     ActivityPath,
     ActivitySplitMetric,
@@ -654,6 +655,159 @@ class TestProcessFitFile:
         run_with_frames(run3_frames)
 
         assert db_session.scalar(select(func.count()).select_from(ActivityPath)) == 0
+
+    def test_process_fit_file_creates_activity_hrv(self, db_session: Session):
+        """
+        Hrv frames flatten into a single ordered activity_hrv row.
+
+        Each frame's `time` field is a tuple of up to 5 R-R intervals right-padded with
+        None; null padding is dropped and values are appended across frames in recorded
+        order, with interval_count matching the flattened length.
+        """
+        _seed_activity(db_session)
+
+        hrv_frame_1 = _make_frame(
+            "hrv", [_make_field("time", (0.528, 0.527, None, None, None))]
+        )
+        hrv_frame_2 = _make_frame(
+            "hrv", [_make_field("time", (0.531, None, None, None, None))]
+        )
+        hrv_frame_3 = _make_frame(
+            "hrv", [_make_field("time", (0.533, 0.539, None, None, None))]
+        )
+
+        processor = self._make_processor()
+        with patch("garmin_health_data.processor.fitdecode") as mock_fitdecode:
+            mock_fitdecode.FIT_FRAME_DATA = fitdecode.FIT_FRAME_DATA
+            mock_fitdecode.FitReader.return_value = _mock_fit_reader(
+                [hrv_frame_1, hrv_frame_2, hrv_frame_3]
+            )
+            processor._process_fit_file(Path(FIT_FILENAME), db_session)
+
+        db_session.commit()
+
+        rows = db_session.execute(select(ActivityHrv)).scalars().all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.activity_id == 12345
+        assert row.interval_count == 5
+        # SQLAlchemy JSON auto-deserializes to a Python list on read.
+        assert isinstance(row.rr_json, list)
+        assert row.rr_json == pytest.approx([0.528, 0.527, 0.531, 0.533, 0.539])
+
+    def test_process_fit_file_no_hrv_skips_activity_hrv(self, db_session: Session):
+        """
+        Files with no hrv frames produce zero activity_hrv rows and do not error.
+        """
+        _seed_activity(db_session)
+
+        ts = datetime(2024, 1, 1, 8, 0, 1, tzinfo=timezone.utc)
+        record_frame = _make_frame(
+            "record",
+            [
+                _make_field("timestamp", ts),
+                _make_field("heart_rate", 150, "bpm"),
+            ],
+        )
+
+        processor = self._make_processor()
+        with patch("garmin_health_data.processor.fitdecode") as mock_fitdecode:
+            mock_fitdecode.FIT_FRAME_DATA = fitdecode.FIT_FRAME_DATA
+            mock_fitdecode.FitReader.return_value = _mock_fit_reader([record_frame])
+            processor._process_fit_file(Path(FIT_FILENAME), db_session)
+
+        db_session.commit()
+
+        assert db_session.scalar(select(func.count()).select_from(ActivityHrv)) == 0
+
+    def test_process_fit_file_hrv_non_iterable_time_skipped(self, db_session: Session):
+        """
+        A malformed (non-iterable) hrv `time` value is skipped without aborting the
+        file; other valid hrv frames are still processed.
+        """
+        _seed_activity(db_session)
+
+        bad_frame = _make_frame("hrv", [_make_field("time", 0.5)])
+        good_frame = _make_frame(
+            "hrv", [_make_field("time", (0.52, 0.53, None, None, None))]
+        )
+
+        processor = self._make_processor()
+        with patch("garmin_health_data.processor.fitdecode") as mock_fitdecode:
+            mock_fitdecode.FIT_FRAME_DATA = fitdecode.FIT_FRAME_DATA
+            mock_fitdecode.FitReader.return_value = _mock_fit_reader(
+                [bad_frame, good_frame]
+            )
+            processor._process_fit_file(Path(FIT_FILENAME), db_session)
+
+        db_session.commit()
+
+        rows = db_session.execute(select(ActivityHrv)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].interval_count == 2
+        assert rows[0].rr_json == pytest.approx([0.52, 0.53])
+
+    def test_process_fit_file_reprocessing_updates_hrv(self, db_session: Session):
+        """
+        Re-running replaces the existing activity_hrv row (delete+insert).
+
+        Reprocessing identical frames is idempotent: still exactly one row with the
+        same content.
+        """
+        _seed_activity(db_session)
+
+        def run_with_frames(frames: list) -> None:
+            processor = self._make_processor()
+            with patch("garmin_health_data.processor.fitdecode") as mock_fitdecode:
+                mock_fitdecode.FIT_FRAME_DATA = fitdecode.FIT_FRAME_DATA
+                mock_fitdecode.FitReader.return_value = _mock_fit_reader(frames)
+                processor._process_fit_file(Path(FIT_FILENAME), db_session)
+            db_session.commit()
+
+        frames = [
+            _make_frame("hrv", [_make_field("time", (0.5, 0.51, None, None, None))]),
+            _make_frame("hrv", [_make_field("time", (0.52, None, None, None, None))]),
+        ]
+
+        # First run: 3 intervals.
+        run_with_frames(frames)
+        rows = db_session.execute(select(ActivityHrv)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].interval_count == 3
+        assert rows[0].rr_json == pytest.approx([0.5, 0.51, 0.52])
+
+        # Re-run identical frames: still exactly one row, same content
+        # (idempotent reprocessing).
+        run_with_frames(frames)
+        rows = db_session.execute(select(ActivityHrv)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].interval_count == 3
+        assert rows[0].rr_json == pytest.approx([0.5, 0.51, 0.52])
+
+        # Re-run with different frames -> delete+insert replaces content.
+        new_frames = [
+            _make_frame("hrv", [_make_field("time", (0.6, None, None, None, None))]),
+        ]
+        run_with_frames(new_frames)
+        rows = db_session.execute(select(ActivityHrv)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].interval_count == 1
+        assert rows[0].rr_json == pytest.approx([0.6])
+
+        # Re-run with no hrv frames at all -> existing row deleted, no new row.
+        no_hrv_frames = [
+            _make_frame(
+                "record",
+                [
+                    _make_field(
+                        "timestamp", datetime(2024, 1, 1, 8, 0, 1, tzinfo=timezone.utc)
+                    ),
+                    _make_field("heart_rate", 150, "bpm"),
+                ],
+            ),
+        ]
+        run_with_frames(no_hrv_frames)
+        assert db_session.scalar(select(func.count()).select_from(ActivityHrv)) == 0
 
 
 # --- Activity base upsert tests --------------------------------------------
@@ -2717,6 +2871,8 @@ class TestProcessTcxFile:
     def test_success_inserts_ts_lap_and_path(self, db_session: Session, tmp_path: Path):
         """
         Full TCX parse: correct ts_metric, lap_metric, and activity_path row counts.
+
+        TCX has no HRV message stream, so activity_hrv stays empty (unaffected).
         """
         _seed_activity(db_session)
         path = _write_tcx(tmp_path, _MINIMAL_TCX)
@@ -2738,6 +2894,8 @@ class TestProcessTcxFile:
         path_row = db_session.execute(select(ActivityPath)).scalars().first()
         assert path_row is not None
         assert path_row.point_count == 2
+        # TCX has no HRV concept.
+        assert db_session.scalar(select(func.count()).select_from(ActivityHrv)) == 0
 
     def test_ts_data_available_set_true(self, db_session: Session, tmp_path: Path):
         """


### PR DESCRIPTION
Fixes #89

## Summary

Adds a new `activity_hrv` table that captures the raw beat-to-beat R-R interval stream from the `hrv` message in activity FIT files, which the parser previously ignored entirely.

- **One row per activity**, `rr_json` (a JSON array of R-R intervals in seconds, in recorded order) plus a denormalized `interval_count`, mirroring the existing `activity_path` precedent (text JSON, not JSONB, for portability across bundled SQLite versions).
- **Parser**: `_process_fit_file` now handles `hrv` frames alongside `record`/`split`/`lap`. Each frame's `time` field is a tuple of up to 5 R-R intervals right-padded with `None`; null padding is dropped and values are flattened across frames in recorded order. A defensive `try/except TypeError` skips a malformed (non-iterable) `time` value without aborting the whole file.
- **Idempotent**: `_persist_activity_metrics` now also delete+inserts `activity_hrv`, so reprocessing an activity replaces its HRV row like every other FIT-derived table. Activities with no compatible HR source (no `hrv` frames) get no row.
- **TCX unaffected**: TCX has no HRV message stream, so `_process_tcx_file` passes `rr_values=None` and `activity_hrv` stays empty for TCX-sourced activities.
- **Distinct from the sleep `hrv` table**: that table holds Garmin's overnight 5-minute sleep HRV summary in milliseconds keyed by `sleep_id` — a different signal, source, and grain. No content overlap; documented explicitly in the DDL comment, the model docstring, and the README.
- **Kept out of `activity_ts_metric`** by design, so `garmin downsample`/`garmin prune` never touch it: averaging R-R intervals into time buckets would collapse them to mean inter-beat time and destroy the successive-beat differences that are the HRV signal (this table is now called out explicitly in the `garmin prune` docs as preserved).

## Validation

- Full test suite green (472 passed, 1 pre-existing skip).
- New unit tests (mock-frame pattern, no `.fit` committed): creates one flattened row with null padding dropped, order preserved, `interval_count` correct; no row when no `hrv` frames; malformed non-iterable `time` value skipped without aborting the file; idempotent reprocessing (re-run same content → still one row; re-run different content → replaced; re-run with no `hrv` frames → row deleted). Extended the cascade-delete integration test and the TCX full-parse test to cover `activity_hrv`.
- Sanity-checked against real FIT files (not committed) with `fitdecode`: confirmed `hrv` frames carry a single tuple-valued `time` field, up to 5 slots, right-padded with `None`, exactly as the issue described. End-to-end run of `_process_fit_file` against a real file with 10,073 `hrv` frames produced 21,912 R-R intervals in a physiologically plausible 0.12s-4.6s range, with no `None` leakage and idempotent on reprocessing.

## Docs

- `README.md`: `activity_hrv` added to the schema tree (Activities: 12 → 13 tables; DB total: 39 → 40, also correcting two comparison-table cells that were already stale at "38 tables"), the duplicate-prevention pattern-1 description, the `garmin prune` preserved-tables list, the Features bullet, and the JSON-over-JSONB example list.
- `CHANGELOG.md`: `### Added` entry under `[Unreleased]`.
